### PR TITLE
Support for dynamic thresholds and concurrency limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ class MyWorker
 end
 ```
 
+You can also supply dynamic values for limits and periods by supplying a proc for these values. The proc will be evaluated at the time the job is fetched and will receive the same arguments that are passed to the job.
+
+``` ruby
+class MyWorker
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+
+  sidekiq_options :queue => :my_queue
+
+  sidekiq_throttle({
+    # Allow maximum 1000 concurrent jobs of this class at a time for VIPs and 10 for all other users.
+    :concurrency => { :limit => User.vip?(user_id) ? 1_000 : 10 },
+    # Allow 1000 jobs/hour to be processed for VIPs and 10/day for all others
+    :threshold => { :limit => ->(user_id) { User.vip?(user_id) ? 1_000 : 10 }, :period => ->(user_id) { User.vip?(user_id) ? 1.hour : 1.day }
+  })
+
+  def perform(user_id)
+    # ...
+  end
+end
+```
 
 ## Supported Ruby Versions
 

--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -47,6 +47,11 @@ module Sidekiq
           (@threshold && @threshold.dynamic_keys?)
       end
 
+      def dynamic_limit?
+        (@concurrency && @concurrency.dynamic_limit?) ||
+          (@threshold && @threshold.dynamic_limit?)
+      end
+
       # @return [Boolean] whenever job is throttled or not.
       def throttled?(jid, *job_args)
         return true if @concurrency && @concurrency.throttled?(jid, *job_args)

--- a/lib/sidekiq/throttled/web/stats.rb
+++ b/lib/sidekiq/throttled/web/stats.rb
@@ -14,7 +14,7 @@ module Sidekiq
 
         # @param [Strategy::Concurrency, Strategy::Threshold] strategy
         def initialize(strategy)
-          if strategy && strategy.dynamic_keys?
+          if strategy && (strategy.dynamic_keys? || strategy.dynamic_limit?)
             raise ArgumentError, "Can't handle strategies with dynamic keys"
           end
           @strategy = strategy

--- a/spec/sidekiq/throttled/basic_fetch_spec.rb
+++ b/spec/sidekiq/throttled/basic_fetch_spec.rb
@@ -13,31 +13,74 @@ RSpec.describe Sidekiq::Throttled::BasicFetch, :sidekiq => :disabled do
       sidekiq_throttle :threshold => { :limit => 5, :period => 10 }
     end
 
-    Sidekiq::Client.push_bulk({
-      "class" => WorkingClass,
-      "args"  => Array.new(10) { [] }
-    })
+    class DynamicWorkingClass
+      include Sidekiq::Worker
+      include Sidekiq::Throttled::Worker
+
+      sidekiq_options :queue => :foo
+      sidekiq_throttle :threshold => {
+        :limit => ->(_) { 5 }, :period => ->(_) { 10 }
+      }
+    end
   end
 
   describe "#retrieve_work" do
     subject(:work) { strategy.retrieve_work }
 
-    it { is_expected.not_to be nil }
+    describe "with static limits" do
+      before do
+        Sidekiq::Client.push_bulk({
+          "class" => WorkingClass,
+          "args"  => Array.new(10) { [] }
+        })
+      end
 
-    context "when limit is not yet reached" do
-      before { 3.times { strategy.retrieve_work } }
       it { is_expected.not_to be nil }
+
+      context "when limit is not yet reached" do
+        before { 3.times { strategy.retrieve_work } }
+        it { is_expected.not_to be nil }
+      end
+
+      context "when limit exceeded" do
+        before { 5.times { strategy.retrieve_work } }
+
+        it { is_expected.to be nil }
+
+        it "pushes fetched job back to the queue" do
+          Sidekiq.redis do |conn|
+            expect(conn).to receive(:lpush)
+            strategy.retrieve_work
+          end
+        end
+      end
     end
 
-    context "when limit exceeded" do
-      before { 5.times { strategy.retrieve_work } }
+    describe "with dynamic limits" do
+      before do
+        Sidekiq::Client.push_bulk({
+          "class" => DynamicWorkingClass,
+          "args"  => Array.new(10) { [] }
+        })
+      end
 
-      it { is_expected.to be nil }
+      it { is_expected.not_to be nil }
 
-      it "pushes fetched job back to the queue" do
-        Sidekiq.redis do |conn|
-          expect(conn).to receive(:lpush)
-          strategy.retrieve_work
+      context "when limit is not yet reached" do
+        before { 3.times { strategy.retrieve_work } }
+        it { is_expected.not_to be nil }
+      end
+
+      context "when limit exceeded" do
+        before { 5.times { strategy.retrieve_work } }
+
+        it { is_expected.to be nil }
+
+        it "pushes fetched job back to the queue" do
+          Sidekiq.redis do |conn|
+            expect(conn).to receive(:lpush)
+            strategy.retrieve_work
+          end
         end
       end
     end

--- a/spec/sidekiq/throttled/strategy/concurrency_spec.rb
+++ b/spec/sidekiq/throttled/strategy/concurrency_spec.rb
@@ -148,6 +148,62 @@ RSpec.describe Sidekiq::Throttled::Strategy::Concurrency do
     end
   end
 
+  describe "with a dynamic limit" do
+    subject(:strategy) do
+      described_class.new :test, :limit => ->(_) { 5 }
+    end
+
+    describe "#throttled?" do
+      subject { strategy.throttled?(jid) }
+
+      context "when limit exceeded" do
+        before { 5.times { strategy.throttled? jid } }
+        it { is_expected.to be true }
+      end
+
+      context "when limit is not exceded" do
+        before { 4.times { strategy.throttled? jid } }
+        it { is_expected.to be false }
+      end
+    end
+
+    describe "#count" do
+      subject { strategy.count }
+      before { 3.times { strategy.throttled? jid } }
+      it { is_expected.to eq 3 }
+    end
+
+    describe "#finalize!" do
+      let(:known_jid) { jid }
+
+      before do
+        4.times { strategy.throttled? jid }
+        strategy.throttled? known_jid
+      end
+
+      it "reduces active concurrency level" do
+        strategy.finalize! known_jid
+        expect(strategy.throttled?(known_jid)).to be false
+      end
+
+      it "allows to run exactly one more job afterwards" do
+        strategy.finalize! known_jid
+        strategy.throttled? known_jid
+
+        expect(strategy.throttled?(jid)).to be true
+      end
+    end
+
+    describe "#reset!" do
+      before { 3.times { strategy.throttled? jid } }
+
+      it "resets count back to zero" do
+        strategy.reset!
+        expect(strategy.count).to eq 0
+      end
+    end
+  end
+
   describe "#dynamic_keys?" do
     let(:strategy) { described_class.new(:test, **kwargs) }
     subject { strategy.dynamic_keys? }
@@ -158,6 +214,21 @@ RSpec.describe Sidekiq::Throttled::Strategy::Concurrency do
     end
 
     describe "without a dynamic key suffix" do
+      let(:kwargs) { { :limit => 5 } }
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#dynamic_limit?" do
+    let(:strategy) { described_class.new(:test, **kwargs) }
+    subject { strategy.dynamic_limit? }
+
+    describe "with a dynamic limit" do
+      let(:kwargs) { { :limit => ->(_) { 5 } } }
+      it { is_expected.to be_truthy }
+    end
+
+    describe "without a dynamic limit" do
       let(:kwargs) { { :limit => 5 } }
       it { is_expected.to be_falsy }
     end

--- a/spec/sidekiq/throttled/strategy/threshold_spec.rb
+++ b/spec/sidekiq/throttled/strategy/threshold_spec.rb
@@ -96,6 +96,51 @@ RSpec.describe Sidekiq::Throttled::Strategy::Threshold do
     end
   end
 
+  describe "with a dynamic limit and period" do
+    subject(:strategy) do
+      described_class.new(
+        :test, :limit => -> (_) { 5 }, :period => -> (_) { 10 }
+      )
+    end
+
+    describe "#throttled?" do
+      subject { strategy.throttled? }
+
+      describe "#throttled?" do
+        subject { strategy.throttled? }
+
+        context "when limit exceeded" do
+          before { 5.times { strategy.throttled? } }
+          it { is_expected.to be true }
+
+          context "and chill period is over" do
+            it { Timecop.travel(Time.now + 11) { is_expected.to be false } }
+          end
+        end
+
+        context "when limit is not exceded" do
+          before { 4.times { strategy.throttled? } }
+          it { is_expected.to be false }
+        end
+      end
+
+      describe "#count" do
+        subject { strategy.count }
+        before { 3.times { strategy.throttled? } }
+        it { is_expected.to eq 3 }
+      end
+
+      describe "#reset!" do
+        before { 3.times { strategy.throttled? } }
+
+        it "resets count back to zero" do
+          strategy.reset!
+          expect(strategy.count).to eq 0
+        end
+      end
+    end
+  end
+
   describe "#dynamic_keys?" do
     let(:strategy) { described_class.new(:test, **kwargs) }
     subject { strategy.dynamic_keys? }
@@ -108,6 +153,30 @@ RSpec.describe Sidekiq::Throttled::Strategy::Threshold do
     end
 
     describe "without a dynamic key suffix" do
+      let(:kwargs) { { :limit => 5, :period => 10 } }
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe "#dynamic_limit?" do
+    let(:strategy) { described_class.new(:test, **kwargs) }
+    subject { strategy.dynamic_limit? }
+
+    describe "with a dynamic limit" do
+      let(:kwargs) do
+        { :limit => ->(_) { 5 }, :period => 10 }
+      end
+      it { is_expected.to be_truthy }
+    end
+
+    describe "with a dynamic period" do
+      let(:kwargs) do
+        { :limit => 5, :period => -> { 10 } }
+      end
+      it { is_expected.to be_truthy }
+    end
+
+    describe "without a dynamic limit or period" do
       let(:kwargs) { { :limit => 5, :period => 10 } }
       it { is_expected.to be_falsy }
     end

--- a/spec/sidekiq/throttled/strategy_spec.rb
+++ b/spec/sidekiq/throttled/strategy_spec.rb
@@ -136,4 +136,23 @@ RSpec.describe Sidekiq::Throttled::Strategy do
       it { is_expected.to be_falsy }
     end
   end
+
+  describe "#dynamic_limit?" do
+    subject { strategy.dynamic_limit? }
+
+    let(:options) { threshold }
+
+    context "when a dynamic limit is being used" do
+      let(:threshold) do
+        { :threshold => { :limit => -> (i) { i }, :period => 10 } }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when a dynamic limit is not being used" do
+      let(:options) { threshold }
+      it { is_expected.to be_falsy }
+    end
+  end
 end

--- a/spec/sidekiq/throttled/web/stats_spec.rb
+++ b/spec/sidekiq/throttled/web/stats_spec.rb
@@ -95,5 +95,27 @@ RSpec.describe Sidekiq::Throttled::Web::Stats do
         expect { described_class.new strategy }.to raise_error(ArgumentError)
       end
     end
+
+    context "with Threshold strategy with a dynamic limit" do
+      let :strategy do
+        Sidekiq::Throttled::Strategy::Threshold.new(
+          :foo, :limit => ->(_) { 10 }, :period => 75
+        )
+      end
+      it "raises an error when instantiated" do
+        expect { described_class.new strategy }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with Threshold strategy with a dynamic limit" do
+      let :strategy do
+        Sidekiq::Throttled::Strategy::Threshold.new(
+          :foo, :limit => 10, :period => ->(_) { 75 }
+        )
+      end
+      it "raises an error when instantiated" do
+        expect { described_class.new strategy }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds support for dynamically specifying limits and periods. This is useful in a number of scenarios, but for the use case in particular that drives this for us is when there are lots of slow running jobs enqueued (>100000), the ability to throttle them dynamically using a configuration value in redis would be ideal. With static values, it would require a redeploy and restart of sidekiq to do this. Would love to get any thoughts on this!
