### PR TITLE
FIX: Seems latest sidekiq do not use unique anymore

### DIFF
--- a/lib/sidekiq/throttled/basic_fetch.rb
+++ b/lib/sidekiq/throttled/basic_fetch.rb
@@ -47,7 +47,8 @@ module Sidekiq
       # @return [Array<String, String>, nil]
       def brpop
         queues = if @strictly_ordered_queues
-                   @unique_queues.dup
+                   # seems latest sidekiq doesnt use unique_queues anymore
+                   @unique_queues.try(:dup) || @queues
                  else
                    @queues.shuffle.uniq
                  end


### PR DESCRIPTION
Latest Sidekiq versions i use does not use `@unique_queues` anymore instead the make `@queues` always unique.
