### PR TITLE
Sleep for TIMEOUT if job was throttled

### DIFF
--- a/lib/sidekiq/throttled/fetch.rb
+++ b/lib/sidekiq/throttled/fetch.rb
@@ -33,6 +33,7 @@ module Sidekiq
         return work unless work.throttled?
 
         work.requeue_throttled
+        sleep TIMEOUT
 
         nil
       end


### PR DESCRIPTION
We sleep for TIMEOUT if no job was received (from redis, or queues list
was empty), thus it makes sense to sleep for same amount of time when
we got job but it was throttled.

This especially makes sense if you have a single queue that is hardly
throttled and has bazillions of jobs in it.
