### PR TITLE
Extend strategy lookup to class ancestors chain

### DIFF
--- a/lib/sidekiq/throttled/queues_pauser.rb
+++ b/lib/sidekiq/throttled/queues_pauser.rb
@@ -2,6 +2,7 @@
 
 require "set"
 require "singleton"
+require "concurrent/timer_task"
 
 require "sidekiq/throttled/patches/queue"
 require "sidekiq/throttled/communicator"

--- a/lib/sidekiq/throttled/registry.rb
+++ b/lib/sidekiq/throttled/registry.rb
@@ -53,8 +53,17 @@ module Sidekiq
         #   @yield [strategy] Gives found strategy to the block
         #   @return result of a block
         def get(name)
-          strategy = @strategies[name.to_s] || @aliases[name.to_s]
+          key = begin
+            Object.const_get(name).ancestors.map(&:name).find do |klass_name|
+              @strategies.key?(klass_name) || @aliases.key?(klass_name)
+            end
+          rescue NameError
+            name.to_s
+          end
+
+          strategy = @strategies[key] || @aliases[key]
           return yield strategy if strategy && block_given?
+
           strategy
         end
 

--- a/spec/sidekiq/throttled/registry_spec.rb
+++ b/spec/sidekiq/throttled/registry_spec.rb
@@ -75,6 +75,28 @@ RSpec.describe Sidekiq::Throttled::Registry do
 
       it { is_expected.to be_a Sidekiq::Throttled::Strategy }
     end
+
+    context "when strategy was registered on a parent class" do
+      let(:parent_class) do
+        class Parent
+        end
+
+        Parent
+      end
+
+      let(:child_class) do
+        class Child < Parent
+        end
+
+        Child
+      end
+
+      let(:name) { child_class.name }
+
+      before { described_class.add(parent_class.name, threshold) }
+
+      it { is_expected.to be_a Sidekiq::Throttled::Strategy }
+    end
   end
 
   describe ".each" do


### PR DESCRIPTION
Currently when specifying a throttling strategy on a parent worker class
the strategy won't be inherited by the child worker class.

This PR extends the registry, so it also looks for the strategy by class ancestors.