### PR TITLE
[WIP] Global throttling

### DIFF
--- a/lib/sidekiq/throttled/registry.rb
+++ b/lib/sidekiq/throttled/registry.rb
@@ -26,7 +26,8 @@ module Sidekiq
 
           warn "Duplicate strategy name: #{name}" if @strategies[name]
 
-          @strategies[name] = Strategy.new(name, **kwargs)
+          args = kwargs.slice(:concurrency, :threshold, :key_suffix)
+          @strategies[name] = Strategy.new(name, args)
         end
 
         # Adds alias for existing strategy.

--- a/lib/sidekiq/throttled/registry.rb
+++ b/lib/sidekiq/throttled/registry.rb
@@ -26,8 +26,7 @@ module Sidekiq
 
           warn "Duplicate strategy name: #{name}" if @strategies[name]
 
-          # FIXME: Modify to `kwargs.slice(:concurrency, :threshold, :key_suffix)` after EOL of Ruby 2.4
-          args = kwargs.select { |k,_| [:concurrency, :threshold, :key_suffix].include? k }
+          args = kwargs.dup.delete_if { |k, _| k == :global_as }
           @strategies[name] = Strategy.new(name, args)
         end
 

--- a/lib/sidekiq/throttled/registry.rb
+++ b/lib/sidekiq/throttled/registry.rb
@@ -26,7 +26,8 @@ module Sidekiq
 
           warn "Duplicate strategy name: #{name}" if @strategies[name]
 
-          args = kwargs.slice(:concurrency, :threshold, :key_suffix)
+          # FIXME: Modify to `kwargs.slice(:concurrency, :threshold, :key_suffix)` after EOL of Ruby 2.4
+          args = kwargs.select { |k,_| [:concurrency, :threshold, :key_suffix].include? k }
           @strategies[name] = Strategy.new(name, args)
         end
 

--- a/lib/sidekiq/throttled/worker.rb
+++ b/lib/sidekiq/throttled/worker.rb
@@ -74,7 +74,12 @@ module Sidekiq
         # @see Registry.add
         # @return [void]
         def sidekiq_throttle(**kwargs)
-          Registry.add(self, **kwargs)
+          if (name = kwargs.dig(:global_as, :name))
+            Registry.add(name, **kwargs) unless Registry.get(name)
+            sidekiq_throttle_as name
+          else
+            Registry.add(self, **kwargs)
+          end
         end
 
         # Adds current worker to preconfigured throtttling strtegy. Allows

--- a/spec/sidekiq/throttled/registry_spec.rb
+++ b/spec/sidekiq/throttled/registry_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe Sidekiq::Throttled::Registry do
       expect(capture_output { described_class.add(working_class, threshold) })
         .to include "Duplicate strategy name: foo"
     end
+
+    context "with global_as argument" do
+      let(:global_as) { { :global_as => { :name => :global_throttle } } }
+      let(:args) { threshold.merge global_as }
+
+      it "does not raise ArgumentError" do
+        expect { described_class.add(working_class, args) }
+          .not_to raise_error ArgumentError
+      end
+    end
   end
 
   describe ".add_alias" do

--- a/spec/sidekiq/throttled/worker_spec.rb
+++ b/spec/sidekiq/throttled/worker_spec.rb
@@ -4,16 +4,51 @@ RSpec.describe Sidekiq::Throttled::Worker do
   let(:working_class) { Class.new { include Sidekiq::Throttled::Worker } }
 
   describe ".sidekiq_throttle" do
-    it "delegates call to Registry.register" do
-      expect(Sidekiq::Throttled::Registry)
-        .to receive(:add).with(working_class, :foo => :bar)
+    context "without global_as argument" do
+      it "delegates call to Registry.add" do
+        expect(Sidekiq::Throttled::Registry)
+          .to receive(:add).with(working_class, :foo => :bar)
 
-      working_class.sidekiq_throttle(:foo => :bar)
+        working_class.sidekiq_throttle(:foo => :bar)
+      end
+    end
+
+    context "with global_as argument" do
+      let(:args) { { :global_as => { :name => :global_throttle } } }
+      let(:name) { args[:global_as][:name] }
+
+      context "when the throttle is not registered yet" do
+        before do
+          allow(Sidekiq::Throttled::Registry).to receive(:get).and_return(false)
+        end
+
+        it "delegates call to Registry.add and calls .sidekiq_throttle_as" do
+          expect(Sidekiq::Throttled::Registry)
+            .to receive(:add).with(name, args)
+          expect(working_class).to receive(:sidekiq_throttle_as).with(name)
+
+          working_class.sidekiq_throttle(args)
+        end
+      end
+
+      context "when the throttle is already registered" do
+        before do
+          allow(Sidekiq::Throttled::Registry).to receive(:get).and_return(true)
+        end
+
+        it "does not delegates and calls .sidekiq_throttle_as" do
+          expect(Sidekiq::Throttled::Registry)
+            .not_to receive(:add).with(working_class, args)
+          expect(working_class).to receive(:sidekiq_throttle_as).with(name)
+
+          working_class.sidekiq_throttle(args)
+        end
+      end
     end
   end
 
   describe ".sidekiq_throttle_as" do
-    it "delegates call to Registry.register" do
+    it "delegates call to Registry.add_alias" do
       expect(Sidekiq::Throttled::Registry)
         .to receive(:add_alias).with(working_class, :foobar)
 


### PR DESCRIPTION
- [x] Make global throttling option
- [x] rubocop
- [x] spec

I wondered if `global_as` was really necessary first, but I found out it was useful in terms of 2 points below.

1. For users who already use `sidekiq-throttled` and want to benefit of Global Throttle without making majority changes
2. To understand how Grobal Throttle is currently managed (necessity of specific name)

ref. https://github.com/sensortower/sidekiq-throttled/issues/44
ref. https://github.com/sensortower/sidekiq-throttled/issues/50