### PR TITLE
Skip Making a Request to Redis if Limit is 0

### DIFF
--- a/lib/sidekiq/throttled/strategy/concurrency.rb
+++ b/lib/sidekiq/throttled/strategy/concurrency.rb
@@ -42,7 +42,9 @@ module Sidekiq
 
         # @return [Boolean] whenever job is throttled or not
         def throttled?(jid, *job_args)
-          return false unless (job_limit = limit(job_args))
+          job_limit = limit(job_args)
+          return false unless job_limit
+          return true if job_limit.zero?
 
           kwargs = {
             :keys => [key(job_args)],

--- a/lib/sidekiq/throttled/strategy/concurrency.rb
+++ b/lib/sidekiq/throttled/strategy/concurrency.rb
@@ -44,7 +44,7 @@ module Sidekiq
         def throttled?(jid, *job_args)
           job_limit = limit(job_args)
           return false unless job_limit
-          return true if job_limit.zero?
+          return true if job_limit <= 0
 
           kwargs = {
             :keys => [key(job_args)],

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -58,7 +58,9 @@ module Sidekiq
 
         # @return [Boolean] whenever job is throttled or not
         def throttled?(*job_args)
-          return false unless (job_limit = limit(job_args))
+          job_limit = limit(job_args)
+          return false unless job_limit
+          return true if job_limit <= 0
 
           kwargs = {
             :keys => [key(job_args)],

--- a/spec/sidekiq/throttled/strategy/concurrency_spec.rb
+++ b/spec/sidekiq/throttled/strategy/concurrency_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe Sidekiq::Throttled::Strategy::Concurrency do
 
         it { is_expected.to be false }
       end
+
+      describe "when limit is 0" do
+        let(:key_input) { initial_key_input }
+        let(:strategy) { described_class.new :test, :limit => 0 }
+
+        it { is_expected.to be true }
+      end
     end
 
     describe "#count" do

--- a/spec/sidekiq/throttled/strategy/concurrency_spec.rb
+++ b/spec/sidekiq/throttled/strategy/concurrency_spec.rb
@@ -108,6 +108,13 @@ RSpec.describe Sidekiq::Throttled::Strategy::Concurrency do
 
         it { is_expected.to be true }
       end
+
+      describe "when limit is negative" do
+        let(:key_input) { initial_key_input }
+        let(:strategy) { described_class.new :test, :limit => -5 }
+
+        it { is_expected.to be true }
+      end
     end
 
     describe "#count" do

--- a/spec/sidekiq/throttled/strategy/threshold_spec.rb
+++ b/spec/sidekiq/throttled/strategy/threshold_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe Sidekiq::Throttled::Strategy::Threshold do
 
         it { is_expected.to be false }
       end
+
+      describe "when limit is 0" do
+        let(:key_input) { initial_key_input }
+        let(:strategy) { described_class.new :test, :limit => 0, :period => 10 }
+
+        it { is_expected.to be true }
+      end
+
+      describe "when limit is negative" do
+        let(:key_input) { initial_key_input }
+        let(:strategy) do
+          described_class.new :test, :limit => -5, :period => 10
+        end
+
+        it { is_expected.to be true }
+      end
     end
 
     describe "#count" do


### PR DESCRIPTION
If the limit is 0 there is no point wasting time and resources to make a request to Redis since we know the job will not be run. 

This is a small performance optimization that would be really useful for my company's use case and I thought it might also be helpful for others. Let me know what you think! Thanks!  