### PR TITLE
Add support of multi key strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,30 @@ class MyWorker
 end
 ```
 
+You also can use several different keys to throttle one worker.
+
+``` ruby
+class MyWorker
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+
+  sidekiq_options :queue => :my_queue
+
+  sidekiq_throttle({
+    # Allow maximum 10 concurrent jobs per project at a time and maximum 2 jobs per user
+    :concurrency => [
+      { :limit => 10, :key_suffix => -> (project_id, user_id) { project_id } },
+      { :limit => 2, :key_suffix => -> (project_id, user_id) { user_id } }
+    ]
+    # For :threshold it works the same
+  })
+
+  def perform(project_id, user_id)
+    # ...
+  end
+end
+```
+
 **NB** Don't forget to specify `:key_suffix` and make it return different values
 if you are using dynamic limit/period options. Otherwise you risk getting into
 some trouble.

--- a/lib/sidekiq/throttled/strategy_collection.rb
+++ b/lib/sidekiq/throttled/strategy_collection.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# internal
+module Sidekiq
+  module Throttled
+    # Collection which transparently group several meta-strategies of one kind
+    #
+    # @private
+    class StrategyCollection
+      include Enumerable
+
+      attr_reader :strategies
+
+      # @param [Hash, Array, nil] strategies Concurrency or Threshold options
+      #   or array of options.
+      #   See keyword args of {Strategy::Concurrency#initialize} for details.
+      #   See keyword args of {Strategy::Threshold#initialize} for details.
+      # @param [Class] strategy class of strategy: Concurrency or Threshold
+      # @param [#to_s] name
+      # @param [#call] key_suffix Dynamic key suffix generator.
+      def initialize(strategies, strategy:, name:, key_suffix:)
+        strategies = (strategies.is_a?(Hash) ? [strategies] : Array(strategies))
+        @strategies = strategies.map do |options|
+          make_strategy(strategy, name, key_suffix, options)
+        end
+      end
+
+      # @param [#call] block
+      # Iterates each strategy in collection
+      def each(&block)
+        @strategies.each(&block)
+      end
+
+      # @return [Boolean] whenever any strategy in collection has dynamic config
+      def dynamic?
+        any?(&:dynamic?)
+      end
+
+      # @return [Boolean] whenever job is throttled or not
+      # by any strategy in collection.
+      def throttled?(*args)
+        any? { |s| s.throttled?(*args) }
+      end
+
+      # Marks job as being processed.
+      # @return [void]
+      def finalize!(*args)
+        each { |c| c.finalize!(*args) }
+      end
+
+      # Resets count of jobs of all avaliable strategies
+      # @return [void]
+      def reset!
+        each(&:reset!)
+      end
+
+      private
+
+      # @return [Base, nil]
+      def make_strategy(strategy, name, key_suffix, options)
+        return unless options
+
+        strategy.new("throttled:#{name}", {
+          :key_suffix => key_suffix,
+          **options
+        })
+      end
+    end
+  end
+end

--- a/lib/sidekiq/throttled/web/throttled.html.erb
+++ b/lib/sidekiq/throttled/web/throttled.html.erb
@@ -14,10 +14,14 @@
       <tr>
         <td style="vertical-align:middle;"><%= name %></td>
         <td style="vertical-align:middle;text-align:center;">
-          <%= Sidekiq::Throttled::Web::Stats.new(strategy.concurrency).to_html %>
+          <% strategy.concurrency.each do |concurrency| %>
+            <%= Sidekiq::Throttled::Web::Stats.new(concurrency).to_html %>
+          <% end %>
         </td>
         <td style="vertical-align:middle;text-align:center;">
-          <%= Sidekiq::Throttled::Web::Stats.new(strategy.threshold).to_html %>
+          <% strategy.threshold.each do |threshold| %>
+            <%= Sidekiq::Throttled::Web::Stats.new(threshold).to_html %>
+          <% end %>
         </td>
         <td style="vertical-align:middle;text-align:center;">
           <form action="<%= root_path %>throttled/<%= CGI.escape name %>/reset" method="post">

--- a/spec/sidekiq/throttled/strategy_collection_spec.rb
+++ b/spec/sidekiq/throttled/strategy_collection_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+RSpec.describe Sidekiq::Throttled::StrategyCollection do
+  let(:collection) { described_class.new(strategies, options) }
+
+  let(:options) do
+    {
+      :strategy   => Sidekiq::Throttled::Strategy::Concurrency,
+      :name       => "test",
+      :key_suffix => nil
+    }
+  end
+
+  describe "#initialize" do
+    context "with no strategies" do
+      let(:strategies) { nil }
+
+      it { expect(collection.count).to eq 0 }
+    end
+
+    context "with one strategy as a Hash" do
+      let(:strategies) do
+        { :limit => 1, :key_suffix => -> (proj_id) { proj_id } }
+      end
+
+      it { expect(collection.count).to eq 1 }
+    end
+
+    context "with couple of strategies as an array" do
+      let(:strategies) do
+        [
+          { :limit => 1, :key_suffix => -> (_proj_id, user_id) { user_id } },
+          { :limit => 10, :key_suffix => -> (proj_id, _user_id) { proj_id } }
+        ]
+      end
+
+      it { expect(collection.count).to eq 2 }
+    end
+  end
+
+  describe "#dynamic?" do
+    subject { collection.dynamic? }
+
+    context "with no dynamic strategy" do
+      let(:strategies) { { :limit => 5 } }
+
+      it { is_expected.to eq false }
+    end
+
+    context "with one dynamic strategy" do
+      let(:strategies) do
+        [
+          { :limit => 1, :key_suffix => -> (_project_id, user_id) { user_id } },
+          { :limit => 10 }
+        ]
+      end
+
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "#throttled?" do
+    subject(:throttled?) { collection.throttled?(*args) }
+
+    let(:args) { [jid, 11, 22] }
+
+    let(:strategies) do
+      [
+        { :limit => 1, :key_suffix => -> (_project_id, user_id) { user_id } },
+        { :limit => 10 }
+      ]
+    end
+
+    let(:strategy1) { collection.strategies[0] }
+    let(:strategy2) { collection.strategies[1] }
+
+    context "with no throttled strategies" do
+      it do
+        allow(strategy1).to receive(:throttled?).with(*args).and_return(false)
+        allow(strategy2).to receive(:throttled?).with(*args).and_return(false)
+
+        expect(throttled?).to eq false
+      end
+    end
+
+    context "with one strategy throttled" do
+      it do
+        allow(strategy1).to receive(:throttled?).with(*args).and_return(false)
+        allow(strategy2).to receive(:throttled?).with(*args).and_return(true)
+
+        expect(throttled?).to eq true
+      end
+    end
+  end
+
+  describe "#finalize!" do
+    subject(:finalize!) { collection.finalize!(job_id, *job_args) }
+
+    let(:job_id) { jid }
+    let(:job_args) { [11, 22] }
+
+    let(:strategies) do
+      [
+        { :limit => 1, :key_suffix => -> (_project_id, user_id) { user_id } },
+        { :limit => 10 }
+      ]
+    end
+
+    it do
+      expect(collection.strategies).to all(
+        receive(:finalize!).with(job_id, *job_args)
+      )
+
+      finalize!
+    end
+  end
+
+  describe "#reset!" do
+    subject(:reset!) { collection.reset! }
+
+    let(:strategies) do
+      [
+        { :limit => 1, :key_suffix => -> (_project_id, user_id) { user_id } },
+        { :limit => 10 }
+      ]
+    end
+
+    it do
+      expect(collection.strategies).to all(receive(:reset!))
+      reset!
+    end
+  end
+end


### PR DESCRIPTION
Hi guys, I hope you would like it )

We are using you nice gem and need this feature to limit concurrent execution of one worker per different entities like user and project, project can have many users, e.g.:

```ruby
sidekiq_throttle({
  # Allow maximum 10 concurrent jobs per project at a time and maximum 2 jobs per user
  :concurrency => [
    { :limit => 10, :key_suffix => -> (project_id, user_id) { project_id } },
    { :limit => 2, :key_suffix => -> (project_id, user_id) { user_id } }
  ]
  # For :threshold it works the same
})
```

Closes https://github.com/sensortower/sidekiq-throttled/issues/17

Here it looks like:

```ruby
sidekiq_throttle threshold: [
  { limit: 100, period: 1.hour }
  { limit: 3, period: 1.minute }
]
```