### PR TITLE
Add note about load order in sidekiq init file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ require "sidekiq/throttled"
 Sidekiq::Throttled.setup!
 ```
 
+Load order can be an issue if you are using other Sidekiq plugins and/or middleware.
+To prevent any problems, add the `.setup!` call to the bottom of your init file.
+
 Once you've done that you can include `Sidekiq::Throttled::Worker` to your
 job classes and configure throttling:
 


### PR DESCRIPTION
When troubleshooting why throttling was not being applied, it was noticed that the call to `Sidekiq::Throttled.setup!` was happening at the top of `initializers/sidekiq.rb` in a rails app. This `.setup!` call was moved to the bottom of the sidekiq initializer file and throttle instantly starting working after restarting sidekiq.

Include a note about this configuration position in the README to prevent future headaches.