### PR TITLE
Fix warnings on Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 matrix:
   fast_finish: true

--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -86,10 +86,7 @@ module Sidekiq
       def make_strategy(strategy, name, key_suffix, options)
         return unless options
 
-        strategy.new("throttled:#{name}", {
-          :key_suffix => key_suffix,
-          **options
-        })
+        strategy.new("throttled:#{name}", key_suffix: key_suffix, **options)
       end
     end
   end

--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -86,7 +86,7 @@ module Sidekiq
       def make_strategy(strategy, name, key_suffix, options)
         return unless options
 
-        strategy.new("throttled:#{name}", key_suffix: key_suffix, **options)
+        strategy.new("throttled:#{name}", :key_suffix => key_suffix, **options)
       end
     end
   end

--- a/lib/sidekiq/throttled/strategy/concurrency.rb
+++ b/lib/sidekiq/throttled/strategy/concurrency.rb
@@ -46,12 +46,10 @@ module Sidekiq
           return false unless job_limit
           return true if job_limit <= 0
 
-          kwargs = {
-            :keys => [key(job_args)],
-            :argv => [jid.to_s, job_limit, @ttl, Time.now.to_f]
-          }
+          keys = [key(job_args)]
+          argv = [jid.to_s, job_limit, @ttl, Time.now.to_f]
 
-          Sidekiq.redis { |redis| 1 == SCRIPT.eval(redis, kwargs) }
+          Sidekiq.redis { |redis| 1 == SCRIPT.eval(redis, keys: keys, argv: argv) }
         end
 
         # @return [Integer] Current count of jobs

--- a/lib/sidekiq/throttled/strategy/concurrency.rb
+++ b/lib/sidekiq/throttled/strategy/concurrency.rb
@@ -49,7 +49,9 @@ module Sidekiq
           keys = [key(job_args)]
           argv = [jid.to_s, job_limit, @ttl, Time.now.to_f]
 
-          Sidekiq.redis { |redis| 1 == SCRIPT.eval(redis, keys: keys, argv: argv) }
+          Sidekiq.redis do |redis|
+            1 == SCRIPT.eval(redis, :keys => keys, :argv => argv)
+          end
         end
 
         # @return [Integer] Current count of jobs

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -65,7 +65,9 @@ module Sidekiq
           keys = [key(job_args)]
           argv = [job_limit, period(job_args), Time.now.to_f]
 
-          Sidekiq.redis { |redis| 1 == SCRIPT.eval(redis, keys: keys, argv: argv) }
+          Sidekiq.redis do |redis|
+            1 == SCRIPT.eval(redis, :keys => keys, :argv => argv)
+          end
         end
 
         # @return [Integer] Current count of jobs

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -62,12 +62,10 @@ module Sidekiq
           return false unless job_limit
           return true if job_limit <= 0
 
-          kwargs = {
-            :keys => [key(job_args)],
-            :argv => [job_limit, period(job_args), Time.now.to_f]
-          }
+          keys = [key(job_args)]
+          argv = [job_limit, period(job_args), Time.now.to_f]
 
-          Sidekiq.redis { |redis| 1 == SCRIPT.eval(redis, kwargs) }
+          Sidekiq.redis { |redis| 1 == SCRIPT.eval(redis, keys: keys, argv: argv) }
         end
 
         # @return [Integer] Current count of jobs

--- a/spec/sidekiq/throttled/registry_spec.rb
+++ b/spec/sidekiq/throttled/registry_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe Sidekiq::Throttled::Registry do
       expect(Sidekiq::Throttled::Strategy)
         .to receive(:new).with("foo", threshold)
 
-      described_class.add(working_class, threshold)
+      described_class.add(working_class, **threshold)
     end
 
     it "registers strategy with with it's #to_s name" do
-      described_class.add(working_class, threshold)
+      described_class.add(working_class, **threshold)
       expect(described_class.get("foo")).to be_a Sidekiq::Throttled::Strategy
     end
 
     it "warns upon duplicate name given" do
-      described_class.add(working_class, threshold)
+      described_class.add(working_class, **threshold)
       expect(capture_output { described_class.add(working_class, threshold) })
         .to include "Duplicate strategy name: foo"
     end
@@ -44,14 +44,14 @@ RSpec.describe Sidekiq::Throttled::Registry do
 
   describe ".add_alias" do
     it "adds aliased name of rquested strategy" do
-      existing_strategy = described_class.add(:foo, concurrency)
+      existing_strategy = described_class.add(:foo, **concurrency)
       described_class.add_alias(:bar, :foo)
       expect(described_class.get(:bar)).to be existing_strategy
     end
 
     it "warns upon duplicate name" do
-      described_class.add(:foo, concurrency)
-      described_class.add(:bar, concurrency)
+      described_class.add(:foo, **concurrency)
+      described_class.add(:bar, **concurrency)
 
       expect(capture_output { described_class.add_alias(:bar, :foo) })
         .to include "Duplicate strategy name: bar"
@@ -73,7 +73,7 @@ RSpec.describe Sidekiq::Throttled::Registry do
     end
 
     context "when strategy was registered" do
-      before { described_class.add(name, threshold) }
+      before { described_class.add(name, **threshold) }
 
       it { is_expected.to be_a Sidekiq::Throttled::Strategy }
     end
@@ -86,7 +86,7 @@ RSpec.describe Sidekiq::Throttled::Registry do
 
       let(:name) { child_class.name }
 
-      before { described_class.add(parent_class.name, threshold) }
+      before { described_class.add(parent_class.name, **threshold) }
 
       it { is_expected.to be_nil }
 
@@ -103,7 +103,7 @@ RSpec.describe Sidekiq::Throttled::Registry do
   describe ".each" do
     let(:names) { %w[foo bar baz] }
 
-    before { names.each { |name| described_class.add(name, threshold) } }
+    before { names.each { |name| described_class.add(name, **threshold) } }
 
     context "when no block given" do
       it "returns Enumerator" do
@@ -130,8 +130,8 @@ RSpec.describe Sidekiq::Throttled::Registry do
 
   describe ".each_with_static_keys" do
     before do
-      described_class.add("foo", threshold)
-      described_class.add("bar", threshold.merge(:key_suffix => -> (i) { i }))
+      described_class.add("foo", **threshold)
+      described_class.add("bar", **threshold.merge(:key_suffix => -> (i) { i }))
     end
 
     it "yields once for each strategy without dynamic key suffixes" do

--- a/spec/sidekiq/throttled/strategy/threshold_spec.rb
+++ b/spec/sidekiq/throttled/strategy/threshold_spec.rb
@@ -143,10 +143,7 @@ RSpec.describe Sidekiq::Throttled::Strategy::Threshold do
 
   describe "with a dynamic limit and period" do
     subject(:strategy) do
-      described_class.new(:test, {
-        :limit  => -> { 5 },
-        :period => -> { 10 }
-      })
+      described_class.new(:test, limit: -> { 5 }, period: -> { 10 })
     end
 
     describe "#throttled?" do

--- a/spec/sidekiq/throttled/strategy/threshold_spec.rb
+++ b/spec/sidekiq/throttled/strategy/threshold_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Sidekiq::Throttled::Strategy::Threshold do
 
   describe "with a dynamic limit and period" do
     subject(:strategy) do
-      described_class.new(:test, limit: -> { 5 }, period: -> { 10 })
+      described_class.new(:test, :limit => -> { 5 }, :period => -> { 10 })
     end
 
     describe "#throttled?" do

--- a/spec/sidekiq/throttled/web/stats_spec.rb
+++ b/spec/sidekiq/throttled/web/stats_spec.rb
@@ -62,10 +62,7 @@ RSpec.describe Sidekiq::Throttled::Web::Stats do
 
     context "with Threshold strategy" do
       let :strategy do
-        Sidekiq::Throttled::Strategy::Threshold.new(:foo, {
-          :limit  => 10,
-          :period => 75
-        })
+        Sidekiq::Throttled::Strategy::Threshold.new(:foo, limit: 10, period: 75)
       end
 
       it { is_expected.to start_with "10 jobs per 1 minute 15 seconds<br />" }

--- a/spec/sidekiq/throttled/web/stats_spec.rb
+++ b/spec/sidekiq/throttled/web/stats_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe Sidekiq::Throttled::Web::Stats do
 
     context "with Threshold strategy" do
       let :strategy do
-        Sidekiq::Throttled::Strategy::Threshold.new(:foo, limit: 10, period: 75)
+        Sidekiq::Throttled::Strategy::Threshold.new(:foo, :limit  => 10,
+                                                          :period => 75)
       end
 
       it { is_expected.to start_with "10 jobs per 1 minute 15 seconds<br />" }

--- a/spec/sidekiq/throttled_spec.rb
+++ b/spec/sidekiq/throttled_spec.rb
@@ -34,9 +34,8 @@ RSpec.describe Sidekiq::Throttled, :sidekiq => :disabled do
 
     it "passes JID to registered strategy" do
       strategy = Sidekiq::Throttled::Registry.add("foo",
-        threshold:   { :limit => 1, :period => 1 },
-        concurrency: { :limit => 1 }
-      )
+        :threshold   => { :limit => 1, :period => 1 },
+        :concurrency => { :limit => 1 })
 
       payload_jid = jid
       message     = %({"class":"foo","jid":#{payload_jid.inspect}})

--- a/spec/sidekiq/throttled_spec.rb
+++ b/spec/sidekiq/throttled_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe Sidekiq::Throttled, :sidekiq => :disabled do
     end
 
     it "passes JID to registered strategy" do
-      strategy = Sidekiq::Throttled::Registry.add("foo", {
-        :threshold   => { :limit => 1, :period => 1 },
-        :concurrency => { :limit => 1 }
-      })
+      strategy = Sidekiq::Throttled::Registry.add("foo",
+        threshold:   { :limit => 1, :period => 1 },
+        concurrency: { :limit => 1 }
+      )
 
       payload_jid = jid
       message     = %({"class":"foo","jid":#{payload_jid.inspect}})


### PR DESCRIPTION
In this PR I fixed runtime warnings generated on Ruby 2.7 and added 2.7 to the build matrix. All warnings from `sidekiq-throttled` are related to keyword arguments changes and are very easy to fix, so no backward incompatible change is required.

Fixes #72.