### PR TITLE
Pass kwargs instead of a hash in strategy_collection.rb

### DIFF
--- a/lib/sidekiq/throttled/strategy_collection.rb
+++ b/lib/sidekiq/throttled/strategy_collection.rb
@@ -60,10 +60,10 @@ module Sidekiq
       def make_strategy(strategy, name, key_suffix, options)
         return unless options
 
-        strategy.new("throttled:#{name}", {
+        strategy.new("throttled:#{name}",
           :key_suffix => key_suffix,
           **options
-        })
+        )
       end
     end
   end


### PR DESCRIPTION
To prevent kwarg warnings with Ruby 2.7 (and incompatibilities with ruby 3):
`lib/sidekiq/throttled/strategy_collection.rb:63: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`