### PR TITLE
Create Sidekiq::Throttled::Job alias

### DIFF
--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -10,6 +10,7 @@ require "sidekiq/throttled/configuration"
 require "sidekiq/throttled/queues_pauser"
 require "sidekiq/throttled/registry"
 require "sidekiq/throttled/worker"
+require "sidekiq/throttled/job"
 require "sidekiq/throttled/utils"
 
 # @see https://github.com/mperham/sidekiq/

--- a/lib/sidekiq/throttled/job.rb
+++ b/lib/sidekiq/throttled/job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "sidekiq/throttled/worker"
+
+module Sidekiq
+  module Throttled
+    # A new module, Sidekiq::Job, was added in Sidekiq version 6.3.0 as a
+    # simple alias for Sidekiq::Worker as the term "worker" was considered
+    # too generic and confusing. Many people call a Sidekiq process a "worker"
+    # whereas others call the thread that executes jobs a "worker".
+    Job = Worker
+  end
+end


### PR DESCRIPTION
This replicates one of the latest [changes in Sidekiq 6.3.0](https://github.com/mperham/sidekiq/blob/main/Changes.md#630). Basically the word "worker" is usually used for the process or thread that's actually processing the jobs in the queue, rather than the jobs themselves. To solve this we just alias `Job` to `Worker`.