### PR TITLE
Update setup-ruby env in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         options: "--entrypoint redis-server"
 
     env:
-      GEMFILE: gemfiles/sidekiq_${{ matrix.sidekiq }}.gemfile
+      BUNDLE_GEMFILE: gemfiles/sidekiq_${{ matrix.sidekiq }}.gemfile
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hi,

I noticed the current Github CI workflow is pulling the latest Sidekiq gem regardless of the specified gemfile. This PR should prevent that.

More details, latest main (example):

- ruby 2.7, sidekiq 5.0
https://github.com/sensortower/sidekiq-throttled/runs/4526523043?check_suite_focus=true

`run ruby/setup-ruby@v1` step output:
```
143   Installing sidekiq 6.3.1
```

With PR changes:
- ruby 2.7, sidekiq 5.0
https://github.com/zrod/sidekiq-throttled/runs/4538987147?check_suite_focus=true

`run ruby/setup-ruby@v1` step output:
```
143   Installing sidekiq 5.0.5
```

More info: https://github.com/ruby/setup-ruby/#matrix-of-gemfiles