### PR TITLE
Report when a key_suffix proc raises an error

### DIFF
--- a/lib/sidekiq/throttled/strategy/base.rb
+++ b/lib/sidekiq/throttled/strategy/base.rb
@@ -12,15 +12,12 @@ module Sidekiq
 
         def key(job_args)
           key = @base_key.dup
-          if @key_suffix
-            begin
-              key << ":#{@key_suffix.call(*job_args)}"
-            rescue Exception => e
-              Sidekiq.logger.error "Failed to get key suffix: #{e}"
-              raise e
-            end
-          end
-          key
+          return key unless @key_suffix
+
+          key << ":#{@key_suffix.call(*job_args)}"
+        rescue => e
+          Sidekiq.logger.error "Failed to get key suffix: #{e}"
+          raise e
         end
       end
     end

--- a/lib/sidekiq/throttled/strategy/base.rb
+++ b/lib/sidekiq/throttled/strategy/base.rb
@@ -12,7 +12,14 @@ module Sidekiq
 
         def key(job_args)
           key = @base_key.dup
-          key << ":#{@key_suffix.call(*job_args)}" if @key_suffix
+          if @key_suffix
+            begin
+              key << ":#{@key_suffix.call(*job_args)}"
+            rescue Exception => e
+              Sidekiq.logger.error "Failed to get key suffix: #{e}"
+              raise e
+            end
+          end
           key
         end
       end


### PR DESCRIPTION
If your `key_suffix` proc raises an error (e.g. its argument count doesn't match `perform`), then sidekiq-throttled [treats the worker as unthrottled](https://github.com/sensortower/sidekiq-throttled/blob/master/lib/sidekiq/throttled.rb#L89-L90). Having a message about the error would have saved us a lot of trouble. Perhaps this PR will help someone else.