### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "2.6", "2.7", "3.0" ]
+        ruby: [ "2.6", "2.7", "3.0", "3.1" ]
         sidekiq: [ "5.0", "5.1", "5.2", "6.0", "6.1", "6.2", "6.3" ]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.