### PR TITLE
Fix Redis 4.6 deprecation warnings

### DIFF
--- a/lib/sidekiq/throttled/fetch/unit_of_work.rb
+++ b/lib/sidekiq/throttled/fetch/unit_of_work.rb
@@ -49,9 +49,14 @@ module Sidekiq
         #   process was terminated. It is a reverse of whatever fetcher was
         #   doing to pull the job out of queue.
         #
+        # @param [Redis] pipelined connection for requeing via Redis#pipelined
         # @return [void]
-        def requeue
-          Sidekiq.redis { |conn| conn.rpush(QueueName.expand(queue_name), job) }
+        def requeue(pipeline = nil)
+          if pipeline
+            pipeline.rpush(QueueName.expand(queue_name), job)
+          else
+            Sidekiq.redis { |conn| conn.rpush(QueueName.expand(queue_name), job) }
+          end
         end
 
         # Pushes job back to the head of the queue, so that job won't be tried


### PR DESCRIPTION
Also prepares the gem for compatibility with Redis 5 

Example warning:
```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end
```

Note: The specs remains unchanged as the behaviour is already verified via https://github.com/sensortower/sidekiq-throttled/blob/master/spec/sidekiq/throttled/fetch_spec.rb#L62-L68

Closes #112