### PR TITLE
Unwrap ActiveJob JobWrapper

### DIFF
--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -77,6 +77,7 @@ module Sidekiq
       def throttled?(message)
         message = JSON.parse message
         job = message.fetch("class") { return false }
+        job = message.fetch("wrapped") { return false } if job == 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper'
         jid = message.fetch("jid") { return false }
 
         preload_constant! job

--- a/spec/sidekiq/throttled_spec.rb
+++ b/spec/sidekiq/throttled_spec.rb
@@ -52,5 +52,18 @@ RSpec.describe Sidekiq::Throttled, :sidekiq => :disabled do
 
       described_class.throttled? message
     end
+
+    it "unwraps ActiveJob-jobs" do
+      strategy = Sidekiq::Throttled::Registry.add("wrapped-foo",
+        :threshold   => { :limit => 1, :period => 1 },
+        :concurrency => { :limit => 1 })
+
+      payload_jid = jid
+      message     = %({"class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper","wrapped":"wrapped-foo","jid":#{payload_jid.inspect}})
+
+      expect(strategy).to receive(:throttled?).with payload_jid
+
+      described_class.throttled? message
+    end
   end
 end


### PR DESCRIPTION
Detect ActiveJob jobs & unwrap to find the 'real' job class. 

We have been using this to throttle mail delivery by overriding the delivery job as follows:

```
class ActionMailer::MailDeliveryJob
  include Sidekiq::Throttled::Worker

  queue_as :default
  sidekiq_throttle(threshold: { limit: 10, period: 1.second })
end
```