### PR TITLE
pass brpop timeout argument as kwarg

### DIFF
--- a/lib/sidekiq/throttled/fetch.rb
+++ b/lib/sidekiq/throttled/fetch.rb
@@ -87,7 +87,7 @@ module Sidekiq
           return
         end
 
-        Sidekiq.redis { |conn| conn.brpop(*queues, TIMEOUT) }
+        Sidekiq.redis { |conn| conn.brpop(*queues, timeout: TIMEOUT) }
       end
 
       # Returns list of queues to try to fetch jobs from.


### PR DESCRIPTION
Passing the timeout as a positional argument is deprecated, it should now be passed as a keyword argument.

```
Passing the timeout as a positional argument is deprecated, it should be passed as a keyword argument:
  redis.brpop("queue:mailers", "queue:api_call", "queue:scheduled", "queue:searchkick", "queue:active_storage_analysis", "queue:active_storage_purge", "queue:default", timeout: 2)(called from: /home/xxx/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sidekiq-throttled-0.16.2/lib/sidekiq/throttled/fetch.rb:94:in `block in brpop')
```

this should fix #124