### PR TITLE
Update redis-prescription

### DIFF
--- a/lib/sidekiq/throttled/strategy/concurrency.rb
+++ b/lib/sidekiq/throttled/strategy/concurrency.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "redis/prescription"
+require "redis-prescription"
 
 require "sidekiq/throttled/strategy/base"
 
@@ -20,7 +20,7 @@ module Sidekiq
         #       PUSH(@key, @jid)
         #       return 0
         #     end
-        SCRIPT = Redis::Prescription.read "#{__dir__}/concurrency.lua"
+        SCRIPT = RedisPrescription.new(File.read("#{__dir__}/concurrency.lua"))
         private_constant :SCRIPT
 
         # @param [#to_s] strategy_key

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "redis/prescription"
+require "redis-prescription"
 
 require "sidekiq/throttled/strategy/base"
 
@@ -30,7 +30,7 @@ module Sidekiq
         #
         #     increase!
         #     return 0
-        SCRIPT = Redis::Prescription.read "#{__dir__}/threshold.lua"
+        SCRIPT = RedisPrescription.new(File.read("#{__dir__}/threshold.lua"))
         private_constant :SCRIPT
 
         # @param [#to_s] strategy_key

--- a/sidekiq-throttled.gemspec
+++ b/sidekiq-throttled.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_runtime_dependency "concurrent-ruby"
-  spec.add_runtime_dependency "redis-prescription"
+  spec.add_runtime_dependency "redis-prescription", ">= 2.2.0"
   spec.add_runtime_dependency "sidekiq", ">= 6.4"
 
   spec.add_development_dependency "bundler", ">= 2.0"


### PR DESCRIPTION
While updating to Ruby 3.2.2, sidekiq-throttled stopped working because the code expected v1 of redis-prescription, which declared Redis::Prescription, but the latest version is now 2.2.0. We couldn't use v1 of redis-prescription because it requires Ruby 2.3. This updates the references so that it's compatible with redis-prescription v2.2.0.