### PR TITLE
Lock `redis-prescription` to `~> 2.4` and update the code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.15.1 (2023-04-10)
+
+* Lock `redis-prescription` to `~> 2.4` and update the code
+
 ## 0.15.0 (2021-12-16)
 
 * [#102](https://github.com/sensortower/sidekiq-throttled/pull/102)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## 0.15.1 (2023-04-10)
 
-* Lock `redis-prescription` to `~> 2.4` and update the code
+* Lock `redis-prescription` to `~> 2.5` and update the code
 
 ## 0.15.0 (2021-12-16)
 

--- a/lib/sidekiq/throttled/strategy/concurrency.rb
+++ b/lib/sidekiq/throttled/strategy/concurrency.rb
@@ -20,7 +20,7 @@ module Sidekiq
         #       PUSH(@key, @jid)
         #       return 0
         #     end
-        SCRIPT = Redis::Prescription.read "#{__dir__}/concurrency.lua"
+        SCRIPT = RedisPrescription.new(File.read("#{__dir__}/concurrency.lua"))
         private_constant :SCRIPT
 
         # @param [#to_s] strategy_key
@@ -50,7 +50,7 @@ module Sidekiq
           argv = [jid.to_s, job_limit, @ttl, Time.now.to_f]
 
           Sidekiq.redis do |redis|
-            1 == SCRIPT.eval(redis, :keys => keys, :argv => argv)
+            1 == SCRIPT.call(redis, :keys => keys, :argv => argv)
           end
         end
 

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -30,7 +30,7 @@ module Sidekiq
         #
         #     increase!
         #     return 0
-        SCRIPT = Redis::Prescription.read "#{__dir__}/threshold.lua"
+        SCRIPT = RedisPrescription.new(File.read("#{__dir__}/threshold.lua"))
         private_constant :SCRIPT
 
         # @param [#to_s] strategy_key
@@ -67,7 +67,7 @@ module Sidekiq
           argv = [job_limit, period(job_args), Time.now.to_f]
 
           Sidekiq.redis do |redis|
-            1 == SCRIPT.eval(redis, :keys => keys, :argv => argv)
+            1 == SCRIPT.call(redis, :keys => keys, :argv => argv)
           end
         end
 

--- a/sidekiq-throttled.gemspec
+++ b/sidekiq-throttled.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
 
   spec.add_runtime_dependency "concurrent-ruby"
-  spec.add_runtime_dependency "redis-prescription"
+  spec.add_runtime_dependency "redis-prescription", "~> 2.4.0"
   spec.add_runtime_dependency "sidekiq"
 
   spec.add_development_dependency "bundler", ">= 2.0"

--- a/sidekiq-throttled.gemspec
+++ b/sidekiq-throttled.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
 
   spec.add_runtime_dependency "concurrent-ruby"
-  spec.add_runtime_dependency "redis-prescription", "~> 2.4.0"
+  spec.add_runtime_dependency "redis-prescription", "~> 2.5"
   spec.add_runtime_dependency "sidekiq"
 
   spec.add_development_dependency "bundler", ">= 2.0"


### PR DESCRIPTION
Make a patch version for 0.15.0 to update and lock `redis-prescription`.