### PR TITLE
fix: middleware not finalizing correctly when job is ActiveJob

### DIFF
--- a/lib/sidekiq/throttled/middleware.rb
+++ b/lib/sidekiq/throttled/middleware.rb
@@ -15,8 +15,13 @@ module Sidekiq
       def call(_worker, msg, _queue)
         yield
       ensure
-        Registry.get msg["class"] do |strategy|
-          strategy.finalize!(msg["jid"], *msg["args"])
+        job = msg.fetch("wrapped") { msg.fetch("class", false) }
+        jid = msg.fetch("jid", false)
+
+        if job && jid
+          Registry.get job do |strategy|
+            strategy.finalize!(jid, *msg["args"])
+          end
         end
       end
     end

--- a/spec/lib/sidekiq/throttled/middleware_spec.rb
+++ b/spec/lib/sidekiq/throttled/middleware_spec.rb
@@ -30,6 +30,36 @@ RSpec.describe Sidekiq::Throttled::Middleware do
       end
     end
 
+    context "when job class has strategy with concurrency constraint and uses ActiveJob" do
+      let(:payload) do
+        {
+          "class"   => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+          "wrapped" => "wrapped-foo",
+          "jid"     => "bar"
+        }
+      end
+
+      let! :strategy do
+        Sidekiq::Throttled::Registry.add payload["wrapped"],
+          concurrency: { limit: 1 }
+      end
+
+      it "calls #finalize! of queue with jid of job being processed" do
+        expect(strategy).to receive(:finalize!).with "bar"
+        middleware.call(double, payload, double) { |*| }
+      end
+
+      it "returns yields control to the given block" do
+        expect { |b| middleware.call(double, payload, double, &b) }
+          .to yield_control
+      end
+
+      it "returns result of given block" do
+        expect(middleware.call(double, payload, double) { |*| :foobar })
+          .to be :foobar
+      end
+    end
+
     context "when job class has strategy without concurrency constraint" do
       let! :strategy do
         Sidekiq::Throttled::Registry.add payload["class"],


### PR DESCRIPTION
I noticed this when I was using concurrency with `ActiveJob`. For the example below, only 2 instances of ExampleJob would process and not clear the lock.

```
class ApplicationJob < ActiveJob::Base
  include Sidekiq::Throttled::Job
end

class ExampleJob < ApplicationJob
  sidekiq_throttle(
    concurrency: { limit: 2 },
  )

  def perform
    # do something
  end
end
```

Digging deeper, this call was missed in earlier changes to support ActiveJob. Fixed that and added tests to prevent regression.