### PR TITLE
Replace "end" with "head" in test cases

### DIFF
--- a/spec/lib/sidekiq/throttled/patches/basic_fetch_spec.rb
+++ b/spec/lib/sidekiq/throttled/patches/basic_fetch_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Sidekiq::Throttled::Patches::BasicFetch do
         expect(fetch.retrieve_work).to be_nil
       end
 
-      it "pushes job back to the end queue" do
+      it "pushes job back to the head of the queue" do
         expect { fetch.retrieve_work }
           .to change { enqueued_jobs("default") }
           .to eq([["ThrottledTestJob", [2]], ["ThrottledTestJob", [3]]])
@@ -74,7 +74,7 @@ RSpec.describe Sidekiq::Throttled::Patches::BasicFetch do
         expect(fetch.retrieve_work).to be_nil
       end
 
-      it "pushes job back to the end queue" do
+      it "pushes job back to the head of the queue" do
         expect { fetch.retrieve_work }
           .to change { enqueued_jobs("default") }
           .to eq([["ThrottledTestJob", [2]], ["ThrottledTestJob", [3]]])


### PR DESCRIPTION
`basic_fetch_spec.rb` tests the behavior of requeue of `retrieve_work`. As far as I see, `requeue_throttled` uses Redis LPUSH, which inserts all the specified values at the head of the list stored at key.

However, the previous test cases were telling
"pushes job back to the end queue". I think this is not correct.

When I was assessing this repository, I was a bit confused by the test case, so I want to correct the test case.