### PR TITLE
Add logic to temporarily skip queue if excessive number of throttled jobs

### DIFF
--- a/lib/sidekiq/throttled/expirable_list.rb
+++ b/lib/sidekiq/throttled/expirable_list.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "monitor"
+
+module Sidekiq
+  module Throttled
+    # List that tracks when elements were added and enumerates over those not
+    # older than `ttl` seconds ago.
+    #
+    # ## Implementation
+    #
+    # Internally list holds an array of arrays. Thus each element is a tuple of
+    # monotonic timestamp (when element was added) and element itself:
+    #
+    #     [
+    #       [ 123456.7890, "default" ],
+    #       [ 123456.7891, "urgent" ],
+    #       [ 123457.9621, "urgent" ],
+    #       ...
+    #     ]
+    #
+    # It does not deduplicates elements. Eviction happens only upon elements
+    # retrieval (see {#each}).
+    #
+    # @see https://ruby-doc.org/core/Process.html#method-c-clock_gettime
+    # @see https://linux.die.net/man/3/clock_gettime
+    #
+    # @private
+    class ExpirableList
+      include Enumerable
+
+      # @param ttl [Float] elements time-to-live in seconds
+      def initialize(ttl)
+        @ttl = ttl.to_f
+        @arr = []
+        @mon = Monitor.new
+      end
+
+      # Pushes given element into the list.
+      #
+      # @params element [Object]
+      # @return [ExpirableList] self
+      def <<(element)
+        @mon.synchronize { @arr << [::Process.clock_gettime(::Process::CLOCK_MONOTONIC), element] }
+        self
+      end
+
+      # Evicts expired elements and calls the given block once for each element
+      # left, passing that element as a parameter.
+      #
+      # @yield [element]
+      # @return [Enumerator] if no block given
+      # @return [ExpirableList] self if block given
+      def each
+        return to_enum __method__ unless block_given?
+
+        @mon.synchronize do
+          horizon = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - @ttl
+
+          # drop all elements older than horizon
+          @arr.shift while @arr[0] && @arr[0][0] < horizon
+
+          @arr.each { |x| yield x[1] }
+        end
+
+        self
+      end
+    end
+  end
+end

--- a/lib/sidekiq/throttled/patches/basic_fetch.rb
+++ b/lib/sidekiq/throttled/patches/basic_fetch.rb
@@ -2,6 +2,7 @@
 
 require "sidekiq"
 require "sidekiq/fetch"
+require "sidekiq/throttled/expirable_list"
 
 module Sidekiq
   module Throttled
@@ -13,6 +14,29 @@ module Sidekiq
           end
         end
 
+        # Timeout to sleep between fetch retries once at least
+        # timeout_after_attempts worth of throttled jobs are hit on a single
+        # queue. These balance scanning through a single queue for unthrottled
+        # jobs and not allowing lower priority queues to be completely starved
+        # by throttled jobs in higher queues
+        TIMEOUT_AFTER_ATTEMPTS = 100
+        TIMEOUT = 1
+
+        def initialize(cap)
+          super
+
+          sidekiq_version = Gem::Version.new(Sidekiq::VERSION)
+          if sidekiq_version < Gem::Version.new("7.0.0")
+            @throttled_queue_cooldown = config.fetch(:throttled_queue_cooldown, TIMEOUT)
+            @throttled_queue_after_attempts = config.fetch(:throttled_queue_after_attempts, TIMEOUT_AFTER_ATTEMPTS)
+          else
+            @throttled_queue_cooldown = config.lookup(:throttled_queue_cooldown) || TIMEOUT
+            @throttled_queue_after_attempts = config.lookup(:throttled_queue_after_attempts) || TIMEOUT_AFTER_ATTEMPTS
+          end
+
+          @paused = ExpirableList.new(@throttled_queue_cooldown)
+        end
+
         # Retrieves job from redis.
         #
         # @return [Sidekiq::Throttled::UnitOfWork, nil]
@@ -21,8 +45,25 @@ module Sidekiq
 
           if work && Throttled.throttled?(work.job)
             requeue_throttled(work)
+
+            if @last_throttled_queue == work.queue_name
+              @last_throttled_count += 1
+            else
+              @last_throttled_queue = work.queue_name
+              @last_throttled_count = 1
+            end
+
+            if @last_throttled_count >= @throttled_queue_after_attempts
+              @paused << work.queue_name
+              @last_throttled_queue = nil
+              @last_throttled_count = 0
+            end
+
             return nil
           end
+
+          @last_throttled_queue = nil
+          @last_throttled_count = 0
 
           work
         end
@@ -51,6 +92,8 @@ module Sidekiq
           # TODO: Refactor to be prepended as an integration mixin during configuration stage
           #   Or via configurable queues reducer
           queues -= Sidekiq::Pauzer.paused_queues.map { |name| "queue:#{name}" } if defined?(Sidekiq::Pauzer)
+
+          queues -= @paused.to_a
 
           queues
         end


### PR DESCRIPTION
This would need tests/documentation before merging, but wanted to open this for discussion.

We recently updated to sidekiq 7 and saw the change in behavior for sidekiq-throttled that the `throttled_queue_cooldown` is no longer used, there seem to be pros and cons of the behavior before and after and this is an attempt to find a better middle ground. The idea is to add back the `throttled_queue_cooldown` concept, but only trigger it after a certain number of throttled jobs are found on a queue.

This reduces a problem with the previous solution where a large number of small jobs that had throttling could end up causing a lot of paused time. As well as helping when a queue has a mix of throttled and unthrottled jobs as the throttled ones will be cycled to the back of the queue faster. It also avoids the problem with the current system where throttled jobs in a high queue can completely starve lower queues, and also reduces the number of fetches that happen in situations where all queued jobs are throttled.

Making this configurable means the old style of throttling can still be achieved by making `throttled_queue_after_attempts` 1, and the new style could be effectively achieved by setting `throttled_queue_after_attempts` to a very large number. In general it seems that different workloads are going to want to tune these settings differently and there probably isn't a one size fits all solution.