### PR TITLE
feat!: Allow ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ ruby-3.0, ruby-3.1, ruby-3.2 ]
+        ruby: [ ruby-2.7, ruby-3.0, ruby-3.1, ruby-3.2 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
     - gemfiles/**/*
     - vendor/**/*
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 2.7
 
 # Broken: https://github.com/rubocop/rubocop/issues/12113
 Bundler/DuplicatedGroup:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2023-12-18
+
+### Added
+
+- Bring back Ruby-2.7.x support
+
+
 ## [1.1.0] - 2023-11-21
 
 ### Changed

--- a/README.adoc
+++ b/README.adoc
@@ -267,6 +267,7 @@ sidekiq_throttle(concurrency: { limit: 20, ttl: 1.hour.to_i })
 
 This library aims to support and is tested against the following Ruby versions:
 
+* Ruby 2.7.x (It works, but not actively maintained and will be dropped in the future)
 * Ruby 3.0.x
 * Ruby 3.1.x
 * Ruby 3.2.x

--- a/README.adoc
+++ b/README.adoc
@@ -267,7 +267,7 @@ sidekiq_throttle(concurrency: { limit: 20, ttl: 1.hour.to_i })
 
 This library aims to support and is tested against the following Ruby versions:
 
-* Ruby 2.7.x (It works, but not actively maintained and will be dropped in the future)
+* Ruby 2.7.x
 * Ruby 3.0.x
 * Ruby 3.1.x
 * Ruby 3.2.x

--- a/lib/sidekiq/throttled/version.rb
+++ b/lib/sidekiq/throttled/version.rb
@@ -3,6 +3,6 @@
 module Sidekiq
   module Throttled
     # Gem version
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/sidekiq-throttled.gemspec
+++ b/sidekiq-throttled.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_runtime_dependency "concurrent-ruby", ">= 1.2.0"
   spec.add_runtime_dependency "redis-prescription", "~> 2.2"


### PR DESCRIPTION
Ruby 2.7 still works, so why not allow it for now while it's free for the maintainers.