### PR TITLE
Properly recover previously throttled orphaned jobs when using Sidekiq Pro's SuperFetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run test suites
         run: |
           if [[ -n "${BUNDLE_GEMS__CONTRIBSYS__COM}" ]]; then
-            cp .rspec.sidekiq-pro .rspec-local
+            cp -f .rspec.sidekiq-pro .rspec
           fi
 
           bundle exec rake test

--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,10 @@ you are using Rails):
 [source,ruby]
 ----
 require "sidekiq/throttled"
+Sidekiq::Throttled.setup!
 ----
+
+Note that if you're using Sidekiq Pro's SuperFetch feature (https://github.com/sidekiq/sidekiq/wiki/Reliability#using-super_fetch), the call to activate SuperFetch (e.g., `config.super_fetch!`) must come _before_ the call to `.setup!`. If you fail to do so, existing throttles will not be cleared correctly for recovered orphaned jobs. To be on the safe side, add the `.setup!` call to the bottom of your init file.
 
 Once you've done that you can include `Sidekiq::Throttled::Job` to your
 job classes and configure throttling:
@@ -304,15 +307,13 @@ And the following Sidekiq Pro versions:
 == Development
 
   bundle install
-  bundle exec appraisal generate
-  bundle exec appraisal install
   bundle exec rake
 
-=== Sidekiq-Pro
+=== Sidekiq Pro
 
-If you're working on Sidekiq-Pro support make sure to copy `.rspec-sidekiq-pro`
-to `.rspec-local` and that you have Sidekiq-Pro license in the global config,
-or in the `BUNDLE_GEMS\__CONTRIBSYS__COM` env variable.
+If you're working on Sidekiq Pro support make sure to copy `.rspec.sidekiq-pro`
+to `.rspec` and that you have a Sidekiq Pro license (username:password combination) in the global Bundler config,
+or in the `BUNDLE_GEMS__CONTRIBSYS__COM` env variable.
 
 == Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ task :test do
   rm_rf "coverage"
   rm_rf "gemfiles"
 
+  persisted_bundler_env = ENV.slice("BUNDLE_GEMS__CONTRIBSYS__COM")
+
   Bundler.with_unbundled_env do
     sh "bundle exec appraisal generate"
 
@@ -18,7 +20,7 @@ task :test do
       end
     end
 
-    sh "bundle exec appraisal rspec --force-colour"
+    sh(persisted_bundler_env, "bundle exec appraisal rspec --force-colour")
   end
 end
 

--- a/lib/sidekiq/throttled/patches/super_fetch.rb
+++ b/lib/sidekiq/throttled/patches/super_fetch.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "sidekiq"
+require "sidekiq/pro/super_fetch"
 
 require_relative "./throttled_retriever"
 
@@ -44,9 +45,4 @@ module Sidekiq
   end
 end
 
-begin
-  require "sidekiq/pro/super_fetch"
-  Sidekiq::Pro::SuperFetch.prepend(Sidekiq::Throttled::Patches::SuperFetch)
-rescue LoadError
-  # Sidekiq Pro is not available
-end
+Sidekiq::Pro::SuperFetch.prepend(Sidekiq::Throttled::Patches::SuperFetch)

--- a/spec/lib/sidekiq/throttled/patches/super_fetch_spec.rb
+++ b/spec/lib/sidekiq/throttled/patches/super_fetch_spec.rb
@@ -1,98 +1,101 @@
 # frozen_string_literal: true
 
-require "sidekiq/throttled/patches/super_fetch"
+if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.0.0")
+  require "sidekiq/throttled/patches/basic_fetch"
+  require "sidekiq/throttled/patches/super_fetch" if Sidekiq.pro?
 
-RSpec.describe Sidekiq::Throttled::Patches::SuperFetch, :sidekiq_pro do
-  let(:base_queue) { "default" }
-  let(:critical_queue) { "critical" }
-  let(:config) do
-    config = Sidekiq.instance_variable_get(:@config)
-    config.super_fetch!
-    config.queues = [base_queue, critical_queue]
-    config
-  end
-  let(:fetch) do
-    config.default_capsule.fetcher
-  end
-
-  before do
-    Sidekiq::Throttled.configure { |config| config.cooldown_period = nil }
-
-    bq = base_queue
-    cq = critical_queue
-    stub_job_class("TestJob") { sidekiq_options(queue: bq) }
-    stub_job_class("AnotherTestJob") { sidekiq_options(queue: cq) }
-
-    allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(0.0)
-
-    # Give super_fetch a chance to finish its initialization, but also check that there are no pre-existing jobs
-    pre_existing_job = fetch.retrieve_work
-    raise "Found pre-existing job: #{pre_existing_job.inspect}" if pre_existing_job
-
-    # Sidekiq is FIFO queue, with head on right side of the list,
-    # meaning jobs below will be stored in 3, 2, 1 order.
-    TestJob.perform_bulk([[1], [2], [3]])
-    AnotherTestJob.perform_async(4)
-  end
-
-  describe "#retrieve_work" do
-    context "when job is not throttled" do
-      it "returns unit of work" do
-        expect(Array.new(4) { fetch.retrieve_work }).to all be_an_instance_of(Sidekiq::Pro::SuperFetch::UnitOfWork)
-      end
+  RSpec.describe Sidekiq::Throttled::Patches::SuperFetch, :sidekiq_pro do
+    let(:base_queue) { "default" }
+    let(:critical_queue) { "critical" }
+    let(:config) do
+      config = Sidekiq.instance_variable_get(:@config)
+      config.super_fetch!
+      config.queues = [base_queue, critical_queue]
+      config
+    end
+    let(:fetch) do
+      config.default_capsule.fetcher
     end
 
-    shared_examples "requeues throttled job" do
-      it "returns nothing" do
-        fetch.retrieve_work
+    before do
+      Sidekiq::Throttled.configure { |config| config.cooldown_period = nil }
 
-        expect(fetch.retrieve_work).to be(nil)
+      bq = base_queue
+      cq = critical_queue
+      stub_job_class("TestJob") { sidekiq_options(queue: bq) }
+      stub_job_class("AnotherTestJob") { sidekiq_options(queue: cq) }
+
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(0.0)
+
+      # Give super_fetch a chance to finish its initialization, but also check that there are no pre-existing jobs
+      pre_existing_job = fetch.retrieve_work
+      raise "Found pre-existing job: #{pre_existing_job.inspect}" if pre_existing_job
+
+      # Sidekiq is FIFO queue, with head on right side of the list,
+      # meaning jobs below will be stored in 3, 2, 1 order.
+      TestJob.perform_bulk([[1], [2], [3]])
+      AnotherTestJob.perform_async(4)
+    end
+
+    describe "#retrieve_work" do
+      context "when job is not throttled" do
+        it "returns unit of work" do
+          expect(Array.new(4) { fetch.retrieve_work }).to all be_an_instance_of(Sidekiq::Pro::SuperFetch::UnitOfWork)
+        end
       end
 
-      it "pushes job back to the head of the queue" do
-        fetch.retrieve_work
-
-        expect { fetch.retrieve_work }
-          .to change { enqueued_jobs(base_queue) }.to([["TestJob", 2], ["TestJob", 3]])
-          .and(keep_unchanged { enqueued_jobs(critical_queue) })
-      end
-
-      context "when queue cooldown kicks in" do
-        before do
-          Sidekiq::Throttled.configure do |config|
-            config.cooldown_period    = 2.0
-            config.cooldown_threshold = 1
-          end
-
+      shared_examples "requeues throttled job" do
+        it "returns nothing" do
           fetch.retrieve_work
+
+          expect(fetch.retrieve_work).to be(nil)
         end
 
-        it "updates cooldown queues" do
+        it "pushes job back to the head of the queue" do
+          fetch.retrieve_work
+
           expect { fetch.retrieve_work }
             .to change { enqueued_jobs(base_queue) }.to([["TestJob", 2], ["TestJob", 3]])
-            .and(change { Sidekiq::Throttled.cooldown.queues }.to(["queue:#{base_queue}"]))
+            .and(keep_unchanged { enqueued_jobs(critical_queue) })
         end
 
-        it "excludes the queue from polling" do
-          fetch.retrieve_work
+        context "when queue cooldown kicks in" do
+          before do
+            Sidekiq::Throttled.configure do |config|
+              config.cooldown_period    = 2.0
+              config.cooldown_threshold = 1
+            end
 
-          expect { fetch.retrieve_work }
-            .to change { enqueued_jobs(critical_queue) }.to([])
-            .and(keep_unchanged { enqueued_jobs(base_queue) })
+            fetch.retrieve_work
+          end
+
+          it "updates cooldown queues" do
+            expect { fetch.retrieve_work }
+              .to change { enqueued_jobs(base_queue) }.to([["TestJob", 2], ["TestJob", 3]])
+              .and(change { Sidekiq::Throttled.cooldown.queues }.to(["queue:#{base_queue}"]))
+          end
+
+          it "excludes the queue from polling" do
+            fetch.retrieve_work
+
+            expect { fetch.retrieve_work }
+              .to change { enqueued_jobs(critical_queue) }.to([])
+              .and(keep_unchanged { enqueued_jobs(base_queue) })
+          end
         end
       end
-    end
 
-    context "when job was throttled due to concurrency" do
-      before { TestJob.sidekiq_throttle(concurrency: { limit: 1 }) }
+      context "when job was throttled due to concurrency" do
+        before { TestJob.sidekiq_throttle(concurrency: { limit: 1 }) }
 
-      include_examples "requeues throttled job"
-    end
+        include_examples "requeues throttled job"
+      end
 
-    context "when job was throttled due to threshold" do
-      before { TestJob.sidekiq_throttle(threshold: { limit: 1, period: 60 }) }
+      context "when job was throttled due to threshold" do
+        before { TestJob.sidekiq_throttle(threshold: { limit: 1, period: 60 }) }
 
-      include_examples "requeues throttled job"
+        include_examples "requeues throttled job"
+      end
     end
   end
 end

--- a/spec/lib/sidekiq/throttled_spec.rb
+++ b/spec/lib/sidekiq/throttled_spec.rb
@@ -3,25 +3,45 @@
 require "json"
 
 RSpec.describe Sidekiq::Throttled do
-  it "registers server middleware" do
-    require "sidekiq/processor"
-    allow(Sidekiq).to receive(:server?).and_return true
-
-    if Sidekiq::VERSION >= "7.0"
-      expect(Sidekiq.default_configuration.server_middleware.exists?(Sidekiq::Throttled::Middlewares::Server))
-        .to be true
-    else
-      expect(Sidekiq.server_middleware.exists?(Sidekiq::Throttled::Middlewares::Server)).to be true
-    end
-  end
-
-  it "infuses Sidekiq::BasicFetch with our patches" do
-    expect(Sidekiq::BasicFetch).to include(Sidekiq::Throttled::Patches::BasicFetch)
-  end
-
   describe ".setup!" do
-    it "shows deprecation warning" do
-      expect { described_class.setup! }.to output(%r{deprecated}).to_stderr
+    it "infuses Sidekiq::BasicFetch with our patches" do
+      described_class.setup!
+
+      expect(Sidekiq::BasicFetch).to include(Sidekiq::Throttled::Patches::BasicFetch)
+    end
+
+    it "registers server middleware" do
+      require "sidekiq/processor"
+
+      described_class.setup!
+
+      allow(Sidekiq).to receive(:server?).and_return true
+
+      if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.0.0")
+        expect(Sidekiq.default_configuration.server_middleware.exists?(Sidekiq::Throttled::Middlewares::Server))
+          .to be true
+      else
+        expect(Sidekiq.server_middleware.exists?(Sidekiq::Throttled::Middlewares::Server)).to be true
+      end
+    end
+
+    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.0.0")
+      context "with SuperFetch", :sidekiq_pro do
+        it "sets up orphan handling" do
+          config = Sidekiq.instance_variable_get(:@config)
+
+          config.super_fetch! do
+            Kernel.exit # Just to test it's being called
+          end
+
+          described_class.setup!
+
+          expect(described_class).to receive(:recover!).with "foo"
+          expect(Kernel).to receive(:exit)
+
+          config.default_capsule.fetcher.notify_orphan("foo")
+        end
+      end
     end
   end
 
@@ -84,6 +104,68 @@ RSpec.describe Sidekiq::Throttled do
       expect(strategy).to receive(:throttled?).with payload_jid
 
       described_class.throttled? message
+    end
+  end
+
+  describe ".recover!" do
+    it "tolerates invalid JSON message" do
+      expect(described_class.recover!("][")).to be false
+    end
+
+    it "tolerates invalid (not fully populated) messages" do
+      expect(described_class.recover!(%({"class" => "foo"}))).to be false
+    end
+
+    it "tolerates if limiter not registered" do
+      message = %({"class":"foo","jid":#{jid.inspect}})
+      expect(described_class.recover!(message)).to be false
+    end
+
+    it "passes JID to registered strategy" do
+      strategy = Sidekiq::Throttled::Registry.add("foo",
+        threshold:   { limit: 1, period: 1 },
+        concurrency: { limit: 1 })
+
+      payload_jid = jid
+      message     = %({"class":"foo","jid":#{payload_jid.inspect}})
+
+      expect(strategy).to receive(:finalize!).with payload_jid
+
+      described_class.recover! message
+    end
+
+    it "unwraps ActiveJob-jobs default sidekiq adapter" do
+      strategy = Sidekiq::Throttled::Registry.add("wrapped-foo",
+        threshold:   { limit: 1, period: 1 },
+        concurrency: { limit: 1 })
+
+      payload_jid = jid
+      message     = JSON.dump({
+        "class"   => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+        "wrapped" => "wrapped-foo",
+        "jid"     => payload_jid
+      })
+
+      expect(strategy).to receive(:finalize!).with payload_jid
+
+      described_class.recover! message
+    end
+
+    it "unwraps ActiveJob-jobs custom sidekiq adapter" do
+      strategy = Sidekiq::Throttled::Registry.add("JobClassName",
+        threshold:   { limit: 1, period: 1 },
+        concurrency: { limit: 1 })
+
+      payload_jid = jid
+      message     = JSON.dump({
+        "class"   => "ActiveJob::QueueAdapters::SidekiqCustomAdapter::JobWrapper",
+        "wrapped" => "JobClassName",
+        "jid"     => payload_jid
+      })
+
+      expect(strategy).to receive(:finalize!).with payload_jid
+
+      described_class.recover! message
     end
   end
 end

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -24,9 +24,6 @@ module SidekiqThrottledHelper
     cfg.redis  = { url: REDIS_URL }
     cfg.logger = PseudoLogger.instance
     cfg.logger.level = Logger::WARN
-    cfg.server_middleware do |chain|
-      chain.add(Sidekiq::Throttled::Middlewares::Server)
-    end
     cfg
   end
 


### PR DESCRIPTION
Without this fix, previously throttled orphaned jobs would remain throttled after being recovered and placed back on the queue.

One downside is that this necessitates the usage of `setup!` once more, as the orphan recovery handler must be registered _after_ SuperFetch has been initialized with `config.super_Fetch!`.

Also fixed the `bundle exec rake` script when running Sidekiq Pro tests with the `BUNDLE_GEMS__CONTRIBSYS__COM` environment variable set.

NOTE: `.rspec-local` does not work (at least with rspec 3.12), you have to override `.rspec` instead.