### PR TITLE
Fix spec_helper for Sidekiq Pro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run test suites
         run: |
           if [[ -n "${BUNDLE_GEMS__CONTRIBSYS__COM}" ]]; then
-            cp .rspec.sidekiq-pro .rspec-local
+            cp .rspec.sidekiq-pro .rspec
           fi
 
           bundle exec rake test

--- a/README.adoc
+++ b/README.adoc
@@ -311,7 +311,7 @@ And the following Sidekiq Pro versions:
 === Sidekiq-Pro
 
 If you're working on Sidekiq-Pro support make sure to copy `.rspec-sidekiq-pro`
-to `.rspec-local` and that you have Sidekiq-Pro license in the global config,
+to `.rspec` and that you have Sidekiq-Pro license in the global config,
 or in the `BUNDLE_GEMS\__CONTRIBSYS__COM` env variable.
 
 == Contributing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,9 @@ RSpec.configure do |config|
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
 
+  # Skip tests that require Sidekiq-Pro
+  config.filter_run_excluding(:sidekiq_pro) unless defined? Sidekiq::Pro
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.


### PR DESCRIPTION
Not sure how this got dropped, but this line is needed to prevent the Sidekiq Pro specs from running in Sidekiq 6.5.

Also, `.rspec-local` isn't actually being respected, so updated guidance to mention `.rspec`