### PR TITLE
Unwrap ActiveJob arguments

### DIFF
--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -77,12 +77,13 @@ module Sidekiq
       def throttled?(message)
         message = Sidekiq.load_json(message)
         job     = message.fetch("wrapped") { message["class"] }
+        args    = message.key?("wrapped") ? message.dig("args", 0, "arguments") : message["args"]
         jid     = message["jid"]
 
         return false unless job && jid
 
         Registry.get(job) do |strategy|
-          return strategy.throttled?(jid, *message["args"])
+          return strategy.throttled?(jid, *args)
         end
 
         false

--- a/lib/sidekiq/throttled/middlewares/server.rb
+++ b/lib/sidekiq/throttled/middlewares/server.rb
@@ -13,12 +13,13 @@ module Sidekiq
         def call(_worker, msg, _queue)
           yield
         ensure
-          job = msg.fetch("wrapped") { msg["class"] }
-          jid = msg["jid"]
+          job  = msg.fetch("wrapped") { msg["class"] }
+          args = msg.key?("wrapped") ? msg.dig("args", 0, "arguments") : msg["args"]
+          jid  = msg["jid"]
 
           if job && jid
             Registry.get job do |strategy|
-              strategy.finalize!(jid, *msg["args"])
+              strategy.finalize!(jid, *args)
             end
           end
         end


### PR DESCRIPTION
When using the `concurrency` strategy with dynamic suffix, I'm getting this error from `sidekiq-throttle`:

`ArgumentError: wrong number of arguments (given 1, expected 2+)`

This happens because the `key_suffix` I'm using is not receiving the proper arguments. Consider this dummy job:

```ruby
class TestJob < ActiveJob::Base
  include Sidekiq::Throttled::Job

  queue_as :default

  sidekiq_throttle(
    concurrency: {
      limit: 1,
      key_suffix: ->(job_class, index, *) { "job_class:#{job_class}/index:#{index}" },
      ttl: 1.hour.to_i
    }
  )

  def perform(job_class, index)
    puts "Job Performed. job_class: #{job_class}, index: #{index}"
  end
end
```

This follows the documentation, which states that `key_suffix` must accept the same parameters as the job. However, `sidekiq-throttle`  fails to unwrap the `ActiveJob` arguments and instead it just calls the `:throttled?` and `:finalize!` methods passing them the arguments in `msg["args"]`, which in `ActiveJob` is an array of JSON objects, like this:

```json
{
  "args": [
    {
      "job_class": "TestJob",
      "job_id": "96f6c127-1e0c-4d8c-bdaa-c934b5aaded7",
      "provider_job_id": null,
      "queue_name": "default",
      "priority": null,
      "arguments": ["TestJob", 9],
      "executions": 0,
      "exception_executions": {},
      "locale": "en",
      "timezone": null,
      "enqueued_at": "2024-03-15T11:31:11.464949297Z",
      "scheduled_at": null
    }
  ]
}
```

Some other methods in the `Concurrency` class like `:count` or `:reset!` also call the `:key` method, so they are vulnerable to this error too. However, I haven't found any place in the code where these methods are called with any parameter.

I wrote a very simple workaround that seems to work fine for my use case, and the test suite passes.