### PR TITLE
sidekiq-throttled.gemspec: Prefer add_dependency

### DIFF
--- a/sidekiq-throttled.gemspec
+++ b/sidekiq-throttled.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_runtime_dependency "concurrent-ruby", ">= 1.2.0"
-  spec.add_runtime_dependency "redis-prescription", "~> 2.2"
-  spec.add_runtime_dependency "sidekiq", ">= 6.5"
+  spec.add_dependency "concurrent-ruby", ">= 1.2.0"
+  spec.add_dependency "redis-prescription", "~> 2.2"
+  spec.add_dependency "sidekiq", ">= 6.5"
 end


### PR DESCRIPTION
This is a lint change, in order to get builds to 🟢 