### PR TITLE
sidekiq-throttled.gemspec: Drop exe/ configuration

### DIFF
--- a/sidekiq-throttled.gemspec
+++ b/sidekiq-throttled.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
     end
   end
 
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7"


### PR DESCRIPTION
This gem exposes no executables.