### PR TITLE
change cooldown default values + explain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change default cooldown period to `1.0` (was `2.0`),
+  and cooldown threshold to `100` (was `1`)
+  [#195](https://github.com/ixti/sidekiq-throttled/pull/195).
+
 ### Removed
 
 - Drop Sidekiq < 7 support
 - Remove deprecated `Sidekiq::Throttled.setup!`
-- Change default cooldown parameter values
 
 ## [1.4.0] - 2024-04-07
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Drop Sidekiq < 7 support
 - Remove deprecated `Sidekiq::Throttled.setup!`
+- Change default cooldown parameter values
 
 ## [1.4.0] - 2024-04-07
 

--- a/README.adoc
+++ b/README.adoc
@@ -99,16 +99,17 @@ Sidekiq::Throttled.configure do |config|
   # Period in seconds to exclude queue from polling in case it returned
   # {config.cooldown_threshold} amount of throttled jobs in a row. Set
   # this value to `nil` to disable cooldown manager completely.
-  # Default: 2.0
-  config.cooldown_period = 2.0
+  # Default: 1.0
+  config.cooldown_period = 1.0
 
   # Exclude queue from polling after it returned given amount of throttled
   # jobs in a row.
-  # Default: 1 (cooldown after first throttled job)
-  config.cooldown_threshold = 1
+  # Default: 100 (cooldown after hundredth throttled job in a row)
+  config.cooldown_threshold = 100
 end
 ----
-
+⚠️ If a queue contains a thousand jobs in a row that will be throttled, the cooldown will kick-in 10 times in a row, meaning it will take 10 seconds before all those jobs are put back at the end of the queue and you actually start processing other jobs. 
+You may want to adjust the cooldown_threshold and cooldown_period, keeping in mind that this will also impact the load on your Redis server.
 
 ==== Middleware(s)
 

--- a/README.adoc
+++ b/README.adoc
@@ -108,8 +108,18 @@ Sidekiq::Throttled.configure do |config|
   config.cooldown_threshold = 100
 end
 ----
-⚠️ If a queue contains a thousand jobs in a row that will be throttled, the cooldown will kick-in 10 times in a row, meaning it will take 10 seconds before all those jobs are put back at the end of the queue and you actually start processing other jobs. 
-You may want to adjust the cooldown_threshold and cooldown_period, keeping in mind that this will also impact the load on your Redis server.
+
+[WARNING]
+.Cooldown Settings
+====
+If a queue contains a thousand jobs in a row that will be throttled,
+the cooldown will kick-in 10 times in a row, meaning it will take 10 seconds
+before all those jobs are put back at the end of the queue and you actually
+start processing other jobs.
+
+You may want to adjust the cooldown_threshold and cooldown_period,
+keeping in mind that this will also impact the load on your Redis server.
+====
 
 ==== Middleware(s)
 

--- a/lib/sidekiq/throttled/config.rb
+++ b/lib/sidekiq/throttled/config.rb
@@ -20,8 +20,8 @@ module Sidekiq
       attr_reader :cooldown_threshold
 
       def initialize
-        @cooldown_period    = 2.0
-        @cooldown_threshold = 1
+        @cooldown_period    = 1.0
+        @cooldown_threshold = 100
       end
 
       # @!attribute [w] cooldown_period

--- a/sidekiq-throttled.gemspec
+++ b/sidekiq-throttled.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_runtime_dependency "concurrent-ruby", ">= 1.2.0"
-  spec.add_runtime_dependency "redis-prescription", "~> 2.2"
-  spec.add_runtime_dependency "sidekiq", ">= 6.5"
+  spec.add_dependency "concurrent-ruby", ">= 1.2.0"
+  spec.add_dependency "redis-prescription", "~> 2.2"
+  spec.add_dependency "sidekiq", ">= 6.5"
 end

--- a/spec/lib/sidekiq/throttled/config_spec.rb
+++ b/spec/lib/sidekiq/throttled/config_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Sidekiq::Throttled::Config do
   describe "#cooldown_period" do
     subject { config.cooldown_period }
 
-    it { is_expected.to eq 2.0 }
+    it { is_expected.to eq 1.0 }
   end
 
   describe "#cooldown_period=" do
@@ -36,7 +36,7 @@ RSpec.describe Sidekiq::Throttled::Config do
   describe "#cooldown_threshold" do
     subject { config.cooldown_threshold }
 
-    it { is_expected.to eq 1 }
+    it { is_expected.to eq 100 }
   end
 
   describe "#cooldown_threshold=" do

--- a/spec/lib/sidekiq/throttled/registry_spec.rb
+++ b/spec/lib/sidekiq/throttled/registry_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Sidekiq::Throttled::Registry do
   describe ".each_with_static_keys" do
     before do
       described_class.add("foo", **threshold)
-      described_class.add("bar", **threshold.merge(key_suffix: ->(i) { i }))
+      described_class.add("bar", **threshold, key_suffix: ->(i) { i })
     end
 
     it "yields once for each strategy without dynamic key suffixes" do


### PR DESCRIPTION
See https://github.com/ixti/sidekiq-throttled/issues/188

I think the default cooldown parameters are poorly chosen, and cause a lot of issues to people starting out with this gem (me included).
The most important part is to update the README to insist on how critical those parameters are. 
And I also think a cooldown_period of 1 and cooldown_threshold of 100 are more reasonable defaults.