### PR TITLE
Store requeue options on Strategy

### DIFF
--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -102,7 +102,7 @@ module Sidekiq
         job_class = Object.const_get(message.fetch("wrapped") { message.fetch("class") { return false } })
 
         Registry.get job_class do |strategy|
-          strategy.requeue_throttled(work, **job_class.sidekiq_throttled_requeue_options)
+          strategy.requeue_throttled(work)
         end
       end
     end

--- a/lib/sidekiq/throttled/job.rb
+++ b/lib/sidekiq/throttled/job.rb
@@ -24,8 +24,6 @@ module Sidekiq
     #
     # @see ClassMethods
     module Job
-      VALID_VALUES_FOR_REQUEUE_WITH = %i[enqueue schedule].freeze
-
       # Extends worker class with {ClassMethods}.
       #
       # @note Using `included` hook with extending worker with {ClassMethods}
@@ -91,13 +89,6 @@ module Sidekiq
         # @see Registry.add
         # @return [void]
         def sidekiq_throttle(**kwargs)
-          requeue_options = Throttled.config.default_requeue_options.merge(kwargs.delete(:requeue) || {})
-          unless VALID_VALUES_FOR_REQUEUE_WITH.include?(requeue_options[:with])
-            raise ArgumentError, "requeue: #{requeue_options[:with]} is not a valid value for :with"
-          end
-
-          self.sidekiq_throttled_requeue_options = requeue_options
-
           Registry.add(self, **kwargs)
         end
 

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -586,7 +586,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
           expect do
             subject.requeue_throttled(work)
-          end.to raise_error(RuntimeError, "unrecognized :with option #{with_proc}")
+          end.to raise_error(RuntimeError, "unrecognized :with option invalid_value")
         end
       end
 

--- a/spec/lib/sidekiq/throttled_spec.rb
+++ b/spec/lib/sidekiq/throttled_spec.rb
@@ -130,10 +130,9 @@ RSpec.describe Sidekiq::Throttled do
       end
     end
 
-    let!(:strategy) { Sidekiq::Throttled::Registry.add("ThrottledTestJob", threshold: { limit: 1, period: 1 }) }
-
-    before do
-      ThrottledTestJob.sidekiq_throttled_requeue_options = { to: :other_queue, with: :enqueue }
+    let!(:strategy) do
+      Sidekiq::Throttled::Registry.add("ThrottledTestJob", threshold: { limit: 1, period: 1 },
+        requeue: { to: :other_queue, with: :enqueue })
     end
 
     it "invokes requeue_throttled on the strategy" do
@@ -141,7 +140,7 @@ RSpec.describe Sidekiq::Throttled do
       job = { class: "ThrottledTestJob", jid: payload_jid.inspect }.to_json
       work = Sidekiq::BasicFetch::UnitOfWork.new("queue:default", job, sidekiq_config)
 
-      expect(strategy).to receive(:requeue_throttled).with(work, to: :other_queue, with: :enqueue)
+      expect(strategy).to receive(:requeue_throttled).with(work)
 
       described_class.requeue_throttled work
     end


### PR DESCRIPTION
This fixes https://github.com/ixti/sidekiq-throttled/issues/198. 

The public interface remains the same, except that now `Registry.add` supports the `requeue` argument, allowing to define a strategy with custom settings for requeuing that can be reused with `sidekiq_throttle_as`.