### PR TITLE
Two bug fixes on the schedule mechanism for requeueing

### DIFF
--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -174,7 +174,7 @@ module Sidekiq
       # Reschedule the job to be executed later in the target queue.
       # The queue name should NOT include the "queue:" prefix, so we remove it if it's present.
       def reschedule_throttled(work, target_queue)
-        target_queue = target_queue.gsub(/^queue:/, "")
+        target_queue = target_queue.gsub(%r{^queue:}, "")
         message = JSON.parse(work.job)
         job_class = message.fetch("wrapped") { message.fetch("class") { return false } }
         job_args = message["args"]

--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -150,7 +150,7 @@ module Sidekiq
 
         target = work.queue if target.nil? || target.empty?
 
-        target.start_with?("queue:") ? target : "queue:#{target}"
+        target.to_s.gsub("queue:", "")
       end
 
       # Push the job back to the head of the queue.
@@ -164,6 +164,8 @@ module Sidekiq
           work.requeue
         else
           # This is the same operation Sidekiq performs upon `Sidekiq::Worker.perform_async` call.
+          # The queue name is expected to include the "queue:" prefix, so we add it if it's missing.
+          target_queue = "queue:#{target_queue}" unless target_queue.start_with?("queue:")
           Sidekiq.redis { |conn| conn.lpush(target_queue, work.job) }
         end
       end

--- a/lib/sidekiq/throttled/strategy_collection.rb
+++ b/lib/sidekiq/throttled/strategy_collection.rb
@@ -43,7 +43,7 @@ module Sidekiq
 
       # @return [Float] How long, in seconds, before we'll next be able to take on jobs
       def retry_in(*args)
-        max { |s| s.retry_in(*args) }
+        map { |s| s.retry_in(*args) }.max
       end
 
       # Marks job as being processed.

--- a/spec/lib/sidekiq/throttled/strategy_collection_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_collection_spec.rb
@@ -90,6 +90,26 @@ RSpec.describe Sidekiq::Throttled::StrategyCollection do
     end
   end
 
+  describe '#retry_in' do
+    let(:strategies) do
+      [
+        { limit: 1, key_suffix: ->(_project_id, user_id) { user_id } },
+        { limit: 10 },
+        { limit: 30 }
+      ]
+    end
+    let(:job_id) { jid }
+
+    it do
+      collection.each_with_index do |s, i|
+        allow(s).to receive(:retry_in).with(job_id, 11, 22).and_return(i * 10)
+      end
+
+      # Returns the max value from the strategies' retry_in returned values
+      expect(collection.retry_in(job_id, 11, 22)).to eq 20
+    end
+  end
+
   describe "#finalize!" do
     subject(:finalize!) { collection.finalize!(job_id, *job_args) }
 

--- a/spec/lib/sidekiq/throttled/strategy_collection_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_collection_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Sidekiq::Throttled::StrategyCollection do
     end
   end
 
-  describe '#retry_in' do
+  describe "#retry_in" do
     let(:strategies) do
       [
         { limit: 1, key_suffix: ->(_project_id, user_id) { user_id } },

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -666,7 +666,17 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           it "returns false and does not reschedule the job" do
             expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
-            expect(subject.send(:reschedule_throttled, work, requeue_to: "default")).to be_falsey
+            expect(subject.send(:reschedule_throttled, work, "queue:default")).to be_falsey
+          end
+        end
+
+        context "when target_queue has the 'queue:' prefix" do
+          let(:target_queue) { "queue:default" }
+
+          it "reschedules the job to the specified queue" do
+            expect(Sidekiq::Client).to receive(:enqueue_to_in).with("default", anything, anything, anything)
+            expect(work).to receive(:acknowledge)
+            subject.send(:reschedule_throttled, work, target_queue)
           end
         end
       end
@@ -998,7 +1008,17 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           it "returns false and does not reschedule the job" do
             expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
-            expect(subject.send(:reschedule_throttled, work, requeue_to: "default")).to be_falsey
+            expect(subject.send(:reschedule_throttled, work, "queue:default")).to be_falsey
+          end
+        end
+
+        context "when target_queue has the 'queue:' prefix" do
+          let(:target_queue) { "queue:default" }
+
+          it "reschedules the job to the specified queue" do
+            expect(Sidekiq::Client).to receive(:enqueue_to_in).with("default", anything, anything, anything)
+            expect(work).to receive(:acknowledge)
+            subject.send(:reschedule_throttled, work, target_queue)
           end
         end
       end

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:default")
+                "queue" => "default")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
 
               # Ensure that the job is no longer in the private queue
@@ -425,7 +425,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:other_queue")
+                "queue" => "other_queue")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
 
               # Ensure that the job is no longer in the private queue
@@ -449,7 +449,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:default")
+                "queue" => "default")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
 
               # Ensure that the job is no longer in the private queue
@@ -475,7 +475,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:other_queue")
+                "queue" => "other_queue")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
 
               # Ensure that the job is no longer in the private queue
@@ -503,7 +503,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
             item, score = scheduled_redis_item_and_score
             expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-              "queue" => "queue:default")
+              "queue" => "default")
             expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
 
             # Ensure that the job is no longer in the private queue
@@ -531,7 +531,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
             item, score = scheduled_redis_item_and_score
             expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-              "queue" => "queue:default")
+              "queue" => "default")
             expect(score.to_f).to be_within(51.0).of(Time.now.to_f + 550.0)
 
             # Ensure that the job is no longer in the private queue
@@ -666,7 +666,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           it "returns false and does not reschedule the job" do
             expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
-            expect(subject.send(:reschedule_throttled, work, requeue_to: "queue:default")).to be_falsey
+            expect(subject.send(:reschedule_throttled, work, requeue_to: "default")).to be_falsey
           end
         end
       end
@@ -807,7 +807,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:default")
+                "queue" => "default")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
             end
           end
@@ -823,7 +823,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:other_queue")
+                "queue" => "other_queue")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
             end
           end
@@ -839,7 +839,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:default")
+                "queue" => "default")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
             end
           end
@@ -859,7 +859,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
               item, score = scheduled_redis_item_and_score
               expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-                "queue" => "queue:other_queue")
+                "queue" => "other_queue")
               expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
             end
           end
@@ -879,7 +879,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
             item, score = scheduled_redis_item_and_score
             expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-              "queue" => "queue:default")
+              "queue" => "default")
             expect(score.to_f).to be_within(31.0).of(Time.now.to_f + 330.0)
           end
         end
@@ -899,7 +899,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
 
             item, score = scheduled_redis_item_and_score
             expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
-              "queue" => "queue:default")
+              "queue" => "default")
             expect(score.to_f).to be_within(51.0).of(Time.now.to_f + 550.0)
           end
         end
@@ -998,7 +998,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           it "returns false and does not reschedule the job" do
             expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
-            expect(subject.send(:reschedule_throttled, work, requeue_to: "queue:default")).to be_falsey
+            expect(subject.send(:reschedule_throttled, work, requeue_to: "default")).to be_falsey
           end
         end
       end


### PR DESCRIPTION
This PR fixes a couple of bugs found while testing the new `schedule` mechanism for putting back jobs on the queue:
- Fixed a bug on how the maximum retry period is calculated from strategies in `StrategyCollection`
- Fixed how the call to re-queue a job is made, to only include the `"queue:"` prefix if needed (when performing a direct `lpush` on redis). This otherwise caused new queues to be created with the extra prefix.