### PR TITLE
Avoid race-condition when scheduling throttled jobs

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,7 +6,7 @@ appraise "sidekiq-7.0.x" do
 
     # Sidekiq Pro license must be set in global bundler config
     # or in BUNDLE_GEMS__CONTRIBSYS__COM env variable
-    install_if "-> { Bundler.settings['gems.contribsys.com']&.include?(':') }" do
+    if Bundler.settings["gems.contribsys.com"]&.include?(":")
       source "https://gems.contribsys.com/" do
         gem "sidekiq-pro", "~> 7.0.0"
       end
@@ -20,7 +20,7 @@ appraise "sidekiq-7.1.x" do
 
     # Sidekiq Pro license must be set in global bundler config
     # or in BUNDLE_GEMS__CONTRIBSYS__COM env variable
-    install_if "-> { Bundler.settings['gems.contribsys.com']&.include?(':') }" do
+    if Bundler.settings["gems.contribsys.com"]&.include?(":")
       source "https://gems.contribsys.com/" do
         gem "sidekiq-pro", "~> 7.1.0"
       end
@@ -34,7 +34,7 @@ appraise "sidekiq-7.2.x" do
 
     # Sidekiq Pro license must be set in global bundler config
     # or in BUNDLE_GEMS__CONTRIBSYS__COM env variable
-    install_if "-> { Bundler.settings['gems.contribsys.com']&.include?(':') }" do
+    if Bundler.settings["gems.contribsys.com"]&.include?(":")
       source "https://gems.contribsys.com/" do
         gem "sidekiq-pro", "~> 7.2.0"
       end

--- a/lib/sidekiq/throttled/strategy/concurrency.rb
+++ b/lib/sidekiq/throttled/strategy/concurrency.rb
@@ -58,6 +58,8 @@ module Sidekiq
           return 0.0 if !job_limit || count(*job_args) < job_limit
 
           oldest_jid_with_score = Sidekiq.redis { |redis| redis.zrange(key(job_args), 0, 0, withscores: true) }.first
+          return 0.0 unless oldest_jid_with_score
+
           expiry_time = oldest_jid_with_score.last.to_f
           expiry_time - Time.now.to_f
         end


### PR DESCRIPTION
When a job was throttled and the queue of pending jobs was fully drained between the throttle? decision and the delay calculation, the retry code would fail with "NoMethodError undefined method `last' for nil:NilClass". I don't see a way to write a test for this since it is very timing based and highly intermittent.

fixes #206

PS: I changed the appraisals file because install_if does all of the bundling work regardless of whether the condition evaluates to true or false. In fact, it fetches the packages list from gems.contribsys.com before it even checks the condition. If BUNDLE_GEMS__CONTRIBSYS__COM isn't set that fetch fails with an auth error.

