### PR TITLE
backlog size aware throttling

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -309,6 +309,43 @@ lock TTL to fit your needs:
 sidekiq_throttle(concurrency: { limit: 20, ttl: 1.hour.to_i })
 ----
 
+=== Scheduling based concurrency tuning
+
+The default concurrency throttling algorithm immediately requeues throttled
+jobs. This can lead to a lot of wasted work picking up the same set of still
+throttled jobs repeatedly. This churn also often starves lower priority
+jobs/queues. The `:schedule` requeue strategy delays checking the runability of
+throttled jobs until likely to be runnable. This future time is estimated based
+on the expected runtime of the job and current number of throttled jobs. This
+eliminates -- or greatly reduces -- the negative impacts to non-throttled job
+types and queues and reduces wasted work constantly rechecking the same still
+throttled jobs.
+
+Config items: 
+* limit - max number of this job to run simultaneously
+* avg_job_duration - expected runtime in seconds of this type of job. Pick a
+  value on the high-side of plausible. Under heavy load values less than the
+  actual average will lead to sub-optimal delays in job processing.
+* lost_job_threshold - duration in seconds of a job's lease on it's concurrency slot
+* ttl - alias for lost_job_threshold
+
+[source,ruby]
+---
+sidekiq_throttle(
+  concurrency: {
+    # only run 10 of this job at a time 
+    limit: 10, 
+    
+    # these jobs finish in less that 30 seconds 
+    avg_job_duration: 30,  
+
+    # if it doesn't release it's lease in 2 minutes it's never going to
+    lost_job_threshold: 120  
+  }, 
+  requeue: { with: :schedule }
+)
+---
+
 
 == Supported Ruby Versions
 

--- a/lib/sidekiq/throttled/strategy/concurrency.lua
+++ b/lib/sidekiq/throttled/strategy/concurrency.lua
@@ -1,16 +1,61 @@
-local key = KEYS[1]
+local in_progress_jobs_key = KEYS[1]
+local backlog_info_key = KEYS[2]
 local jid = ARGV[1]
 local lmt = tonumber(ARGV[2])
-local ttl = tonumber(ARGV[3])
+local lost_job_threshold = tonumber(ARGV[3])
 local now = tonumber(ARGV[4])
 
-redis.call("ZREMRANGEBYSCORE", key, "-inf", "(" .. now)
+-- supporting functions
+local function over_limit()
+  return lmt <= redis.call("ZCARD", in_progress_jobs_key)
+end
 
-if lmt <= redis.call("ZCARD", key) and not redis.call("ZSCORE", key, jid) then
+local function job_already_in_progress()
+  return redis.call("ZSCORE", in_progress_jobs_key, jid)
+end
+
+-- Estimates current backlog size. This function tends to underestimate 
+-- the actual backlog. This is intentional. Overestimates are bad as it
+-- can cause unnecessary delays in job processing. Underestimates are much
+-- safer as they only increase workload of sidekiq processors. 
+local function est_current_backlog_size()
+  local old_size = tonumber(redis.call("HGET", backlog_info_key, "size") or 0)
+  local old_timestamp = tonumber(redis.call("HGET", backlog_info_key, "timestamp") or now)
+  
+  local jobs_lost_since_old_timestamp = (now - old_timestamp) / lost_job_threshold * lmt
+
+  return math.max(old_size - jobs_lost_since_old_timestamp, 0) 
+end
+
+
+local function change_backlog_size(delta)
+  local curr_backlog_size = est_current_backlog_size()
+
+  redis.call("HSET", backlog_info_key, "size", curr_backlog_size + delta) 
+  redis.call("HSET", backlog_info_key, "timestamp", now)
+  redis.call("EXPIRE", backlog_info_key, math.ceil((lost_job_threshold * curr_backlog_size) + 1 / lmt))
+end
+
+local function register_job_in_progress()
+  redis.call("ZADD", in_progress_jobs_key, now + lost_job_threshold , jid)
+  redis.call("EXPIRE", in_progress_jobs_key, lost_job_threshold)
+end
+
+local function clear_stale_in_progress_jobs()
+  local cleared_count = redis.call("ZREMRANGEBYSCORE", in_progress_jobs_key, "-inf", "(" .. now)
+  change_backlog_size(-cleared_count)
+end
+
+-- END supporting functions
+
+clear_stale_in_progress_jobs()
+
+if over_limit() and not job_already_in_progress() then
+  change_backlog_size(1)
   return 1
 end
 
-redis.call("ZADD", key, now + ttl, jid)
-redis.call("EXPIRE", key, ttl)
+register_job_in_progress()
+change_backlog_size(-1)
 
 return 0

--- a/lib/sidekiq/throttled/strategy/concurrency.lua
+++ b/lib/sidekiq/throttled/strategy/concurrency.lua
@@ -19,8 +19,8 @@ end
 -- can cause unnecessary delays in job processing. Underestimates are much
 -- safer as they only increase workload of sidekiq processors. 
 local function est_current_backlog_size()
-  local old_size = tonumber(redis.call("HGET", backlog_info_key, "size") or 0)
-  local old_timestamp = tonumber(redis.call("HGET", backlog_info_key, "timestamp") or now)
+  local old_size = tonumber(redis.call("HGET", backlog_info_key, "size")) or 0
+  local old_timestamp = tonumber(redis.call("HGET", backlog_info_key, "timestamp")) or now
   
   local jobs_lost_since_old_timestamp = (now - old_timestamp) / lost_job_threshold * lmt
 

--- a/lib/sidekiq/throttled/web/stats.rb
+++ b/lib/sidekiq/throttled/web/stats.rb
@@ -62,12 +62,13 @@ module Sidekiq
 
         # @return [String]
         def humanize_integer(int)
-          digits = int.to_s.chars
-          str    = digits.shift(digits.count % 3).join
-
-          str << " " << digits.shift(3).join while digits.count.positive?
-
-          str.strip
+          int.to_s.chars
+            .reverse
+            .each_slice(3)
+            .map(&:reverse)
+            .reverse
+            .map(&:join)
+            .join(",")
         end
       end
     end

--- a/spec/lib/sidekiq/throttled/strategy/concurrency_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy/concurrency_spec.rb
@@ -3,6 +3,27 @@
 RSpec.describe Sidekiq::Throttled::Strategy::Concurrency do
   subject(:strategy) { described_class.new :test, limit: 5 }
 
+  describe "#initialize" do
+    it "accepts all parameters" do
+      expect(
+        described_class.new(:test, limit: 5, avg_job_duration: 300, lost_job_threshold: 900, key_suffix: -> { "xxx" })
+      ).to be_a described_class
+    end
+
+    it "accepts ttl as alias of lost_job_threshold" do
+      expect(
+        described_class.new(:test, limit: 5, avg_job_duration: 300, ttl: 900)
+      ).to be_a described_class
+    end
+
+    it "doesn't allow lost_job_threshold > avg_job_duration" do
+      expect do
+        described_class.new(:test, limit: 5, avg_job_duration: 300, lost_job_threshold: 100)
+      end
+        .to raise_error ArgumentError
+    end
+  end
+
   describe "#throttled?" do
     subject { strategy.throttled? jid }
 
@@ -38,27 +59,88 @@ RSpec.describe Sidekiq::Throttled::Strategy::Concurrency do
         expect(strategy.throttled?(jid)).to be false
       end
     end
+
+    context "when ttl is explicitly set to non-default value" do
+      subject(:strategy) { described_class.new :test, limit: 5, ttl: 1000 }
+
+      it "invalidates expired locks avoiding strategy starvation" do
+        5.times { strategy.throttled? jid }
+
+        Timecop.travel(Time.now + 900) do
+          expect(strategy.throttled?(jid)).to be true
+        end
+
+        Timecop.travel(Time.now + 1000) do
+          expect(strategy.throttled?(jid)).to be false
+        end
+      end
+    end
+
+    context "when lost_job_threshold is explicitly set to non-default value" do
+      subject(:strategy) { described_class.new :test, limit: 5, lost_job_threshold: 1000 }
+
+      it "invalidates expired locks avoiding strategy starvation" do
+        5.times { strategy.throttled? jid }
+
+        Timecop.travel(Time.now + 900) do
+          expect(strategy.throttled?(jid)).to be true
+        end
+
+        Timecop.travel(Time.now + 1000) do
+          expect(strategy.throttled?(jid)).to be false
+        end
+      end
+    end
   end
 
   describe "#retry_in" do
     context "when limit is exceeded with all jobs starting just now" do
       before { 5.times { strategy.throttled? jid } }
 
-      it "tells us to wait roughly one ttl" do
-        expect(subject.retry_in(jid)).to be_within(0.1).of(900)
+      it "tells us to wait roughly the expected time between job completions (expected job duration / max concurrency)" do # rubocop:disable Layout/LineLength
+        strategy.throttled? jid # register that we are delaying this job
+
+        expect(subject.retry_in(jid)).to be_within(1).of(300 / 5)
       end
     end
 
-    context "when limit exceeded, with first job starting 800 seconds ago" do
+    context "when there is a deep backlog of this type of job" do
+      before { 15.times { |a_jid| strategy.throttled? a_jid } }
+
+      it "tells us to wait a time proportional to the approximate backlog size" do
+        expect(subject.retry_in(jid)).to be_within(1).of(10 * 300 / 5)
+      end
+    end
+
+    context "when some jobs have finished" do
       before do
-        Timecop.travel(Time.now - 800) do
-          strategy.throttled? jid
-        end
-        4.times { strategy.throttled? jid }
+        (1..15).each { |a_jid| strategy.throttled? a_jid } # 5 in-progress; 10 delayed jobs
+        (1..5).each { |a_jid| strategy.finalize! a_jid } # finish in-progress jobs
+        (6..10).each { |a_jid| strategy.throttled? a_jid } # start next batch of job
       end
 
-      it "tells us to wait 100 seconds" do
-        expect(subject.retry_in(jid)).to be_within(0.1).of(100)
+      it "tells us to wait a time proportional to the remaining backlog" do
+        expect(subject.retry_in(jid)).to be_within(1).of(5 * 300 / 5)
+      end
+    end
+
+    context "when created with non-default job duration not the default" do
+      subject(:strategy) { described_class.new :fast_job_test, limit: 5, avg_job_duration: 15 }
+
+      before { 15.times { |a_jid| strategy.throttled? a_jid } }
+
+      it "takes the explicit job duration into account" do
+        expect(subject.retry_in(jid)).to be_within(1).of(10 * 15 / 5)
+      end
+    end
+
+    context "when jobs that don't get subtracted backlog size because of a bug or something crashed" do
+      before { 15.times { |a_jid| strategy.throttled? a_jid } }
+
+      it "doesn't delay jobs forever" do
+        Timecop.travel(Time.now + (24 * 60 * 60)) do
+          expect(subject.retry_in(jid)).to eq 0
+        end
       end
     end
 

--- a/spec/lib/sidekiq/throttled/web/stats_spec.rb
+++ b/spec/lib/sidekiq/throttled/web/stats_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe Sidekiq::Throttled::Web::Stats do
       end
     end
 
+    context "with Concurrency strategy with large limit" do
+      let :strategy do
+        Sidekiq::Throttled::Strategy::Concurrency.new(:foo, limit: 1000)
+      end
+
+      it { is_expected.to start_with "1,000 jobs<br />" }
+    end
+
     context "with Threshold strategy" do
       let :strategy do
         Sidekiq::Throttled::Strategy::Threshold.new(:foo, limit:  10,


### PR DESCRIPTION
This PR changes the `retry_in` calculation for concurrency throttled jobs using the `:schedule` strategy. The approach is to estimate when a throttled job will likely be runnable and schedule it for that time. This estimate is based on the current backlog size for the job group (estimated), the expected job runtime and the concurrency limit. 

This should reduce/eliminate unnecessary delays in job processing caused by the current "ignore throttled jobs for TTL seconds" approach while retaining the benefits of the schedule strategy. 


PS: I changed the appraisals file because install_if does all of the bundling work regardless of whether the condition evaluates to true or false. In fact, it fetches the packages list from gems.contribsys.com before it even checks the condition. If BUNDLE_GEMS__CONTRIBSYS__COM isn't set that fetch failed with an auth error.