### PR TITLE
Fix string key suffix behavior

### DIFF
--- a/lib/sidekiq/throttled/strategy/base.rb
+++ b/lib/sidekiq/throttled/strategy/base.rb
@@ -14,7 +14,11 @@ module Sidekiq
           key = @base_key.dup
           return key unless @key_suffix
 
-          key << ":#{@key_suffix.call(*job_args)}"
+          key << ":#{key_suffix(job_args)}"
+        end
+
+        def key_suffix(job_args)
+          @key_suffix.respond_to?(:call) ? @key_suffix.call(*job_args) : @key_suffix
         rescue StandardError => e
           Sidekiq.logger.error "Failed to get key suffix: #{e}"
           raise e

--- a/spec/lib/sidekiq/throttled/strategy/threshold_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy/threshold_spec.rb
@@ -288,4 +288,20 @@ RSpec.describe Sidekiq::Throttled::Strategy::Threshold do
       it { is_expected.to be_falsy }
     end
   end
+
+  describe "with string key suffix" do
+    subject(:strategy) do
+      described_class.new(:test, limit: 2, period: 10, key_suffix: "xxx")
+    end
+
+    describe "#throttled?" do
+      subject { strategy.throttled? }
+
+      before do
+        3.times { strategy.throttled? }
+      end
+
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
When using a string key suffix, an error is thrown because the key suffix is not a proc. Fix this by checking if the key suffix is a proc and calling it if it is. If it's not a proc, it's returned as is.

Resolves https://github.com/ixti/sidekiq-throttled/issues/204