### PR TITLE
Clarify that key_suffix is not scoped to each strategy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -270,8 +270,8 @@ class MyJob
   sidekiq_throttle(
     # Allow maximum 10 concurrent jobs per project at a time and maximum 2 jobs per user
     concurrency: [
-      { limit: 10, key_suffix: -> (project_id, user_id) { project_id } },
-      { limit: 2, key_suffix: -> (project_id, user_id) { user_id } }
+      { limit: 10, key_suffix: -> (project_id, user_id) { "project_id:#{product_id}" } },
+      { limit: 2, key_suffix: -> (project_id, user_id) { "user_id:#{user_id}" } }
     ]
     # For :threshold it works the same
   )

--- a/README.adoc
+++ b/README.adoc
@@ -270,7 +270,7 @@ class MyJob
   sidekiq_throttle(
     # Allow maximum 10 concurrent jobs per project at a time and maximum 2 jobs per user
     concurrency: [
-      { limit: 10, key_suffix: -> (project_id, user_id) { "project_id:#{product_id}" } },
+      { limit: 10, key_suffix: -> (project_id, user_id) { "project_id:#{project_id}" } },
       { limit: 2, key_suffix: -> (project_id, user_id) { "user_id:#{user_id}" } }
     ]
     # For :threshold it works the same

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -144,6 +144,18 @@ RSpec.describe Sidekiq::Throttled::Strategy do
         }
       end
 
+      context "when both rules result in the same suffix" do
+        let(:job_args) { [1] }
+
+        # This puts 3 jobs under the key_suffix "1", due to the second rule.
+        before { 3.times { strategy.throttled? jid, 99 } }
+
+        # Since the arg is 1 the key_suffix for the first rule will be "1".
+        # There are already 3 jobs under this key, and the limit is 3, so the
+        # job is throttled.
+        it { is_expected.to be true }
+      end
+
       context "with first concurrency rule" do
         let(:job_args) { [11] }
 


### PR DESCRIPTION
This PR updates the README example showing multiple concurrency strategies to make sure they generate different key suffixes. Previously the example was misleading because the calculated key suffixes could overlap, causing surprising behavior.

The example says it is intended to

> Allow maximum 10 concurrent jobs per project at a time and maximum 2 jobs per user

But if there were two jobs running with project_id `1` then all jobs for user_id `1` would also be throttled, because there would already be two jobs under the key `1`. This is probably not the intended behavior.

This PR also adds a spec to demonstrate the behavior.

@ixti do you have any other suggestions on how to clarify this behavior? Or do you think it should be considered a bug?