### PR TITLE
Don't count job as in progress if a different strategy throttles it

### DIFF
--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -112,7 +112,7 @@ module Sidekiq
         end
       end
 
-      # Marks job as being processed.
+      # Marks job as not processing.
       # @return [void]
       def finalize!(jid, *job_args)
         @concurrency&.finalize!(jid, *job_args)

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -93,7 +93,7 @@ module Sidekiq
           Sidekiq.redis { |conn| conn.llen(key(job_args)) }.to_i
         end
 
-        # Marks job as being processed.
+        # Marks job as not processing.
         # No tracking of this is necessary for threshold.
         # @return [void]
         def finalize!(...); end

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -93,6 +93,11 @@ module Sidekiq
           Sidekiq.redis { |conn| conn.llen(key(job_args)) }.to_i
         end
 
+        # Marks job as being processed.
+        # No tracking of this is necessary for threshold.
+        # @return [void]
+        def finalize!(...); end
+
         # Resets count of jobs
         # @return [void]
         def reset!(*job_args)

--- a/lib/sidekiq/throttled/strategy_collection.rb
+++ b/lib/sidekiq/throttled/strategy_collection.rb
@@ -38,7 +38,18 @@ module Sidekiq
       # @return [Boolean] whenever job is throttled or not
       # by any strategy in collection.
       def throttled?(...)
-        any? { |s| s.throttled?(...) }
+        allows = []
+
+        each do |s|
+          if s.throttled?(...)
+            allows.each { |s| s.finalize!(...) }
+            return true
+          else
+            allows << s
+          end
+        end
+
+        false
       end
 
       # @return [Float] How long, in seconds, before we'll next be able to take on jobs

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
         {
           concurrency: [
             { limit: 7, key_suffix: ->(_, *) { 1 } },
-            { limit: 3, key_suffix: ->(job_arg, *) { job_arg } },
+            { limit: 3, key_suffix: ->(job_arg, *) { job_arg } }
           ]
         }
       end
@@ -180,7 +180,7 @@ RSpec.describe Sidekiq::Throttled::Strategy do
             in_progress_count += 4.times.count { !strategy.throttled? jid, [99] }
             in_progress_count += 3.times.count { |i| !strategy.throttled? jid, i }
 
-            expect(in_progress_count).to eq(6)
+            raise "unexpected in_progress_count" if in_progress_count != 6
           end
 
           it { is_expected.to be false }

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -138,13 +138,13 @@ RSpec.describe Sidekiq::Throttled::Strategy do
       let(:concurrency) do
         {
           concurrency: [
+            { limit: 7, key_suffix: ->(_, *) { 1 } },
             { limit: 3, key_suffix: ->(job_arg, *) { job_arg } },
-            { limit: 7, key_suffix: ->(_, *) { 1 } }
           ]
         }
       end
 
-      context "with first concurrency rule" do
+      context "with dynamic key suffix" do
         let(:job_args) { [11] }
 
         context "when limit is not yet reached" do
@@ -168,11 +168,20 @@ RSpec.describe Sidekiq::Throttled::Strategy do
         end
       end
 
-      context "with second concurrency rule" do
+      context "with static key suffix" do
         let(:job_args) { [10] }
 
         context "when limit is not yet reached" do
-          before { 6.times { |i| strategy.throttled? jid, i } }
+          before do
+            in_progress_count = 0
+
+            # Since there is a limit of 3 the 4th job will not be
+            # enqueued and should not count towards the static limit of 7.
+            in_progress_count += 4.times.count { !strategy.throttled? jid, [99] }
+            in_progress_count += 3.times.count { |i| !strategy.throttled? jid, i }
+
+            expect(in_progress_count).to eq(6)
+          end
 
           it { is_expected.to be false }
         end


### PR DESCRIPTION
When strategies are given in an array`throttled?` is [called in order for each strategy in the array](https://github.com/ixti/sidekiq-throttled/blob/854dffec6704fbd0a3a719474299c6d98bb16284/lib/sidekiq/throttled/strategy_collection.rb#L38-L42). When it is called for one concurrency strategy and evaluates to `false` it [always adds the job to the in progress set](https://github.com/ixti/sidekiq-throttled/blob/854dffec6704fbd0a3a719474299c6d98bb16284/lib/sidekiq/throttled/strategy/concurrency.lua#L58-L61). But if it evaluates to `true` for a later strategy then the job will not actually be executed.

This PR fixes this bug by calling `finalize!` on each strategy that `throttled?` was already called on, removing the job from their in progress sets. This is a similar to how `Strategy#throttled?` already [calls `finalize!` on its concurrency strategies](https://github.com/ixti/sidekiq-throttled/blob/854dffec6704fbd0a3a719474299c6d98bb16284/lib/sidekiq/throttled/strategy.rb#L79) that were already evaluated if the threshold strategy throttles the job.

It seems inefficient to add each job to sets only to immediately remove it. A possibly more efficient approach is shown in https://github.com/CJStadler/sidekiq-throttled/commit/12c4f35689020. That would require more extensive changes though.

Fixes https://github.com/ixti/sidekiq-throttled/issues/220