### PR TITLE
Fix lock leak in multiple concurrency strategies

### DIFF
--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -67,9 +67,11 @@ module Sidekiq
       end
 
       # @return [Boolean] whenever job is throttled or not.
-      def throttled?(jid, *job_args)
+      def throttled?(jid, *job_args) # rubocop:disable Metrics/MethodLength
         if @concurrency&.throttled?(jid, *job_args)
           @observer&.call(:concurrency, *job_args)
+
+          finalize!(jid, *job_args)
           return true
         end
 

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -205,6 +205,37 @@ RSpec.describe Sidekiq::Throttled::Strategy do
       end
     end
 
+    context "when throttled by a later concurrency strategy in the collection" do
+      let(:options) do
+        {
+          concurrency: [
+            { limit: 5, key_suffix: ->(*) { "global" } },
+            { limit: 1, key_suffix: ->(*) { "per_tenant" } }
+          ]
+        }
+      end
+
+      before do
+        # Saturate the second concurrency strategy (per_tenant limit = 1)
+        # by running a different job through it first
+        strategy.throttled?("seed-jid")
+      end
+
+      it "releases the first strategy's lock when the second strategy throttles" do
+        first_strategy = strategy.concurrency.strategies.first
+
+        # Confirm the second strategy is at capacity before our call
+        expect(strategy.concurrency.strategies.last.count).to eq(1)
+
+        # This call should be throttled by the second strategy (per_tenant is full)
+        expect(strategy.throttled?(jid)).to be true
+
+        # The first strategy must NOT have a leaked lock for jid.
+        # Count should remain 1 (from seed-jid only), not 2.
+        expect(first_strategy.count).to eq(1)
+      end
+    end
+
     context "when both concurrency and threshold given" do
       let(:options) { threshold.merge concurrency }
 


### PR DESCRIPTION
When multiple concurrency strategies are configured as an array, StrategyCollection#throttled? uses any? to check each in order. If an earlier strategy passes (acquiring a slot) but a later one throttles, any? short-circuits and
 returns true. Strategy#throttled? then returned early without calling finalize!, leaking the slot acquired by the earlier strategy.

Fix: call finalize! in the concurrency-throttled branch, consistent with what was already done in the threshold-throttled branch.