### PR TITLE
doc: Fix requeue option placement in throttle examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -91,7 +91,8 @@ It may be configured on a per job basis with:
 ```ruby
   sidekiq_throttle(
     # Allow 5 jobs to processed within 1 minute, using the 
-    threshold: { limit: 5, period: 1.minute, requeue: {with: :schedule} }
+    threshold: { limit: 5, period: 1.minute },
+    requeue: { with: :schedule }
   )
 ```
 
@@ -100,7 +101,8 @@ It is also possible to requeue jobs to another queue:
 ```ruby
   sidekiq_throttle(
     # Allow 5 jobs to processed within 1 minute, using the 
-    threshold: { limit: 5, period: 1.minute, requeue: {to: :other_queue, with: :schedule} }
+    threshold: { limit: 5, period: 1.minute },
+    requeue: { to: :other_queue, with: :schedule }
   )
 ```
 


### PR DESCRIPTION
The "Requeue Strategy" examples nest `requeue` inside the `threshold` hash. Following them raises:

```ArgumentError: unknown keyword: :requeue```

`requeue` is a top-level option of `sidekiq_throttle`, alongside `threshold` and `concurrency` - see `Strategy#initialize` in `lib/sidekiq/throttled/strategy.rb`. The README already uses the correct form further down, in the concurrency example, so the file contradicted itself.

Fixes #232